### PR TITLE
add yalc setup to scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,18 @@ Some addons, which don't have the helpers and components registered, might be ad
 - `cd documentation`
 - `yarn test` – Runs the test suite on the current Ember version
 - `yarn test:watch` – Runs the test suite in "watch mode"
+- 
+## Testing in dependent projects 
 
+### Publishing toolkit locally
+- `cd toolkit`
+- `yarn toolkit:publish` – Publishing `@hashocorp/consul-ui-toolkit` to local `.yalc` store
+- from the dependent project `yalc link @hashocorp/consul-ui-toolkit`
+
+### Remove toolkit package from local .yalc store
+- `cd toolkit`
+- `yarn toolkit:clenup` – Removing `@hashocorp/consul-ui-toolkit` from local `.yalc` store
+- 
 ## Running the test application
 
 - `cd documentation`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,13 @@ Some addons, which don't have the helpers and components registered, might be ad
 ## Testing in dependent projects 
 
 ### Publishing toolkit locally
-- `cd toolkit`
-- `yarn toolkit:publish` – Publishing `@hashocorp/consul-ui-toolkit` to local `.yalc` store
+- from root `publish:local:toolkit`
+- or `cd toolkit` and `yarn publish:local` – Publishing `@hashocorp/consul-ui-toolkit` to local `.yalc` store
 - from the dependent project `yalc link @hashocorp/consul-ui-toolkit`
 
 ### Remove toolkit package from local .yalc store
-- `cd toolkit`
-- `yarn toolkit:clenup` – Removing `@hashocorp/consul-ui-toolkit` from local `.yalc` store
+- from root `clenup:local:toolkit`
+- or `cd toolkit` and `yarn cleanup:local` – Removing `@hashocorp/consul-ui-toolkit` from local `.yalc` store
 - 
 ## Running the test application
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Some addons, which don't have the helpers and components registered, might be ad
 - from the dependent project `yalc link @hashocorp/consul-ui-toolkit`
 
 ### Remove toolkit package from local .yalc store
-- from root `clenup:local:toolkit`
+- from root `cleanup:local:toolkit`
 - or `cd toolkit` and `yarn cleanup:local` – Removing `@hashocorp/consul-ui-toolkit` from local `.yalc` store
 - 
 ## Running the test application

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "yarn workspace @hashicorp/consul-ui-toolkit run build",
     "changeset": "changeset",
-    "clenup:local:toolkit": "yarn workspace @hashicorp/consul-ui-toolkit run cleanup:local",
+    "cleanup:local:toolkit": "yarn workspace @hashicorp/consul-ui-toolkit run cleanup:local",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
     "lint:types": "yarn workspaces run lint:types",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "scripts": {
     "build": "yarn workspace @hashicorp/consul-ui-toolkit run build",
     "changeset": "changeset",
+    "clenup:local:toolkit": "yarn workspace @hashicorp/consul-ui-toolkit run cleanup:local",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
     "lint:types": "yarn workspaces run lint:types",
     "prepare": "yarn build",
     "prerelease": "yarn prepare",
+    "publish:local:toolkit": "yarn workspace @hashicorp/consul-ui-toolkit run publish:local",
     "release": "changeset publish",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace @hashicorp/consul-ui-toolkit run start",

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
+    "cleanup:local": "yalc installations clean @hashicorp/consul-ui-toolkit",
     "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",
     "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:'",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
@@ -25,11 +26,10 @@
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "toolkit:publish": "yalc publish --content",
-    "toolkit:cleanup": "yalc installations clean @hashicorp/consul-ui-toolkit",
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in documentation'",
-    "prepack": "rollup --config"
+    "prepack": "rollup --config",
+    "publish:local": "yalc publish --content"
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0"
@@ -72,9 +72,7 @@
     "version": 2,
     "type": "addon",
     "main": "addon-main.cjs",
-    "app-js": {
-      "./components/cut/consul-cards-why-consul-component/index.js": "./dist/_app_/components/cut/consul-cards-why-consul-component/index.js"
-    }
+    "app-js": {}
   },
   "exports": {
     ".": "./dist/index.js",

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -25,6 +25,8 @@
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
+    "toolkit:publish": "yalc publish --content",
+    "toolkit:cleanup": "yalc installations clean @hashicorp/consul-ui-toolkit",
     "start": "rollup --config --watch",
     "test": "echo 'A v2 addon does not have tests, run tests in documentation'",
     "prepack": "rollup --config"


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
A description of how we can use [Yalc](https://github.com/wclr/yalc) can be found in the [RFC](https://go.hashi.co/rfc/csl-3822). There isn’t a ton to “add to the repo” except a script for publishing the local build to yalc, and a script for cleanup if it seems like it would be helpful. It would also be good to include documentation on how to use yalc with the toolkit.

**AC**
Add script for publishing builds with yalc (optionally one for cleanup as well)

Add documentation on how to use yalc with the toolkit
### :camera_flash: Screenshots

### :link: External Links
[RFC](https://go.hashi.co/rfc/csl-3822)
[Yalc](https://github.com/wclr/yalc)
https://hashicorp.atlassian.net/browse/CC-4211
<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change
- cd toolkit 
- yarn toolkit:publish
- yarn toolkit:cleanup

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
