### PR TITLE
CC-5064: add changesets version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace @hashicorp/consul-ui-toolkit run start",
     "start:documentation": "yarn workspace documentation run start",
-    "test": "yarn workspaces run test"
+    "test": "yarn workspaces run test",
+    "version": "yarn changeset version && yarn install --mode update-lockfile"
   },
   "devDependencies": {
     "concurrently": "^7.2.1",


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
The [release action has been failing](https://github.com/hashicorp/consul-ui-toolkit/actions/runs/4994640794/jobs/8945486986). There is an error mentioning that there are no changes after the version script is ran. Looks like I needed to add a yarn script for calling the changesets version command. At least that's what I think needed to happen :). Based this on the [design-system package.json scripts](https://github.com/hashicorp/design-system/blob/5012cd96f609b4951927bf5568bdb461305481dd/package.json#L15) and ran it locally to see that there would indeed be changes to commit.

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-5064](https://hashicorp.atlassian.net/browse/CC-5064)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-5064]: https://hashicorp.atlassian.net/browse/CC-5064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ