### PR TITLE
Add component api docs component

### DIFF
--- a/.changeset/short-moose-turn.md
+++ b/.changeset/short-moose-turn.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update rollup-ts and related dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -81,7 +81,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/documentation/app/components/component-api/index.hbs
+++ b/documentation/app/components/component-api/index.hbs
@@ -1,3 +1,7 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+}}
+
 <dl class="doc-componentApi">
   <div class="doc-componentApi-name">
     <dt>Name</dt>
@@ -11,7 +15,7 @@
     </div>
   {{/if}}
 
-  {{#if @default}}
+  {{#if (and @default (not @values))}}
     <div class="doc-componentApi-default">
       <dt>Default</dt>
       <dd><Hds::Badge

--- a/documentation/app/components/component-api/index.hbs
+++ b/documentation/app/components/component-api/index.hbs
@@ -1,0 +1,46 @@
+<dl class="doc-componentApi">
+  <div class="doc-componentApi-name">
+    <dt>Name</dt>
+    <dd><Hds::Badge @text={{@name}} @type="inverted" /></dd>
+  </div>
+
+  {{#if @type}}
+    <div class="doc-componentApi-type">
+      <dt>Type</dt>
+      <dd class="hds-font-family-mono-code">{{@type}}</dd>
+    </div>
+  {{/if}}
+
+  {{#if @default}}
+    <div class="doc-componentApi-default">
+      <dt>Default</dt>
+      <dd><Hds::Badge
+          @text={{@default}}
+          @color="highlight"
+          @type="inverted"
+        /></dd>
+    </div>
+  {{/if}}
+
+  {{#if @values}}
+    <div class="doc-componentApi-values">
+      <dt>Values</dt>
+      <dd>
+        {{#each @values as |value|}}
+          <Hds::Badge
+            @text={{value}}
+            @color="highlight"
+            @type={{if (eq value @default) "inverted" "filled"}}
+          />
+        {{/each}}
+      </dd>
+    </div>
+  {{/if}}
+
+  {{#if @description}}
+    <div class="doc-componentApi-description">
+      <dt>Description</dt>
+      <dd>{{@description}}</dd>
+    </div>
+  {{/if}}
+</dl>

--- a/documentation/app/components/component-api/index.hbs
+++ b/documentation/app/components/component-api/index.hbs
@@ -18,11 +18,7 @@
   {{#if (and @default (not @values))}}
     <div class="doc-componentApi-default">
       <dt>Default</dt>
-      <dd><Hds::Badge
-          @text={{@default}}
-          @color="highlight"
-          @type="inverted"
-        /></dd>
+      <dd><Hds::Badge @text={{@default}} @type="inverted" /></dd>
     </div>
   {{/if}}
 
@@ -33,7 +29,6 @@
         {{#each @values as |value|}}
           <Hds::Badge
             @text={{value}}
-            @color="highlight"
             @type={{if (eq value @default) "inverted" "filled"}}
           />
         {{/each}}

--- a/documentation/app/styles/app.scss
+++ b/documentation/app/styles/app.scss
@@ -3,6 +3,7 @@
  */
 @import "@hashicorp/design-system-components";
 @import "@hashicorp/consul-ui-toolkit";
+@import "./components/component-api";
 @import "./components/page-header";
 @import "./components/preview-block.scss";
 @import "./components/in-page-nav.scss";
@@ -147,6 +148,7 @@ pre {
 
     .docs-Page-content {
       max-width: 800px;
+      flex-grow: 1;
     }
   }
 }

--- a/documentation/app/styles/components/component-api.scss
+++ b/documentation/app/styles/components/component-api.scss
@@ -5,11 +5,7 @@
 .doc-componentApi {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-areas:
-    "name type"
-    "default default"
-    "values values"
-    "description description";
+  grid-template-areas: "name type";
   grid-auto-flow: row;
   gap: 1rem;
   padding: 1.5rem 1rem;
@@ -37,14 +33,14 @@
   }
 
   .doc-componentApi-default {
-    grid-area: default;
+    grid-column: 1/3;
   }
 
   .doc-componentApi-values {
-    grid-area: values;
+    grid-column: 1/3;
   }
 
   .doc-componentApi-description {
-    grid-area: description;
+    grid-column: 1/3;
   }
 }

--- a/documentation/app/styles/components/component-api.scss
+++ b/documentation/app/styles/components/component-api.scss
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 .doc-componentApi {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/documentation/app/styles/components/component-api.scss
+++ b/documentation/app/styles/components/component-api.scss
@@ -1,0 +1,46 @@
+.doc-componentApi {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    "name type"
+    "default default"
+    "values values"
+    "description description";
+  grid-auto-flow: row;
+  gap: 1rem;
+  padding: 1.5rem 1rem;
+  margin: 0;
+  border-bottom: var(--token-form-control-border-width) solid
+    var(--token-color-border-primary);
+  width: 100%;
+
+  dt {
+    font-weight: var(--token-typography-display-100-font-size);
+    font-weight: var(--token-typography-font-weight-semibold);
+    margin-bottom: 0.5rem;
+  }
+
+  dd {
+    margin-left: 0;
+  }
+
+  .doc-componentApi-name {
+    grid-area: name;
+  }
+
+  .doc-componentApi-type {
+    grid-area: type;
+  }
+
+  .doc-componentApi-default {
+    grid-area: default;
+  }
+
+  .doc-componentApi-values {
+    grid-area: values;
+  }
+
+  .doc-componentApi-description {
+    grid-area: description;
+  }
+}

--- a/documentation/app/templates/components/list-item.hbs
+++ b/documentation/app/templates/components/list-item.hbs
@@ -79,7 +79,44 @@
     <div class="docs-Page">
       <div class="docs-Page-content">
         <h2 id="how-to-use">How to use this component</h2>
-        <p>
+        <h3 id="href">Href</h3>
+        <h3 id="is-href-external">isHrefExternal</h3>
+        <h3 id="route">Route</h3>
+        <h3 id="is-route-external">isRouteExternal</h3>
+        <h3 id="query">Query</h3>
+        <h3 id="replace">Replace</h3>
+        <h3 id="onClick">OnClick</h3>
+
+        <ComponentApi
+          @name="href"
+          @type="string"
+          @default="apply"
+          @description="a href to somewhere far away"
+          @values={{array "help" "wanted" "please" "apply" "inside"}}
+        />
+        <ComponentApi
+          @name="href"
+          @type="string"
+          @default="apply"
+          @description="a href to somewhere far away"
+          @values={{array "help" "wanted" "please" "apply" "inside"}}
+        />
+        <ComponentApi
+          @name="href"
+          @type="string"
+          @default="apply"
+          @description="a href to somewhere far away"
+          @values={{array "help" "wanted" "please" "apply" "inside"}}
+        />
+        <ComponentApi
+          @name="href"
+          @type="string"
+          @default="apply"
+          @description="a href to somewhere far away"
+          @values={{array "help" "wanted" "please" "apply" "inside"}}
+        />
+
+        {{!-- <p>
           The most basic invocation requires the
           <CodeInline @code="type" />
           argument to be passed, along with the
@@ -242,7 +279,7 @@
         </PreviewBlock>
         <h2 id="example-section">Example Section</h2>
         <p>This section is below the fold so I can demo the link to hash working
-          properly</p>
+          properly</p> --}}
       </div>
       <InPageNav as |I|>
         <I.Link @section="#how-to-use" @depth={{1}}>How to usue this component</I.Link>

--- a/documentation/app/templates/components/list-item.hbs
+++ b/documentation/app/templates/components/list-item.hbs
@@ -78,213 +78,30 @@
   <T.Panel>
     <div class="docs-Page">
       <div class="docs-Page-content">
-        <h2 id="how-to-use">How to use this component</h2>
-        <h3 id="href">Href</h3>
-        <h3 id="is-href-external">isHrefExternal</h3>
-        <h3 id="route">Route</h3>
-        <h3 id="is-route-external">isRouteExternal</h3>
-        <h3 id="query">Query</h3>
-        <h3 id="replace">Replace</h3>
-        <h3 id="onClick">OnClick</h3>
+        <h2 id="component-api">Component API</h2>
 
         <ComponentApi
           @name="href"
           @type="string"
-          @default="apply"
           @description="a href to somewhere far away"
-          @values={{array "help" "wanted" "please" "apply" "inside"}}
         />
         <ComponentApi
-          @name="href"
+          @name="type"
           @type="string"
-          @default="apply"
-          @description="a href to somewhere far away"
-          @values={{array "help" "wanted" "please" "apply" "inside"}}
+          @default="neutral"
+          @description="Determines the color of the component"
+          @values={{array "success" "neutral" "warning" "critical"}}
         />
         <ComponentApi
-          @name="href"
-          @type="string"
-          @default="apply"
-          @description="a href to somewhere far away"
-          @values={{array "help" "wanted" "please" "apply" "inside"}}
-        />
-        <ComponentApi
-          @name="href"
-          @type="string"
-          @default="apply"
-          @description="a href to somewhere far away"
-          @values={{array "help" "wanted" "please" "apply" "inside"}}
+          @name="isHrefExternal"
+          @type="boolean"
+          @default="true"
+          @description="Determines if the anchor should open the link in a new tab or not"
         />
 
-        {{!-- <p>
-          The most basic invocation requires the
-          <CodeInline @code="type" />
-          argument to be passed, along with the
-          <CodeInline @code="title" />
-          and/or
-          <CodeInline @code="description" />
-          content. By default, a neutral
-          <CodeInline @code="alert" />
-          is generated.
-        </p>
-
-        <PreviewBlock as |P|>
-          <P.Preview>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          </P.Preview>
-          <P.Code
-            @code={{{"
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          "}}}
-            @language="handlebars"
-          />
-        </PreviewBlock>
-
-        <h3 id="type">Type</h3>
-        <p>A different type of alert can be invoked using the
-          <CodeInline @code="type" />
-          argument</p>
-
-        <PreviewBlock as |P|>
-          <P.Preview>
-            <Hds::Alert @type="page" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          </P.Preview>
-          <P.Code
-            @code={{{"
-            <Hds::Alert @type='page' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          "}}}
-            @language="handlebars"
-          />
-        </PreviewBlock>
-
-        <PreviewBlock as |P|>
-          <P.Preview>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type="inline" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          </P.Preview>
-          <P.Code
-            @code={{{"
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Example of a very long description to show that it scrolls both ways and all is good in the world.</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-            <Hds::Alert @type='inline' as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          "}}}
-            @language="handlebars"
-          />
-        </PreviewBlock>
-
-        <PreviewBlock as |P|>
-          <P.Preview>
-            <Hds::Alert @type="compact" as |A|>
-              <A.Title>Title here</A.Title>
-              <A.Description>Description here</A.Description>
-            </Hds::Alert>
-          </P.Preview>
-
-          <P.Code
-            @code={{{"
-              <Hds::Alert @type='compact' as |A|>
-                <A.Title>Title here</A.Title>
-                <A.Description>Description here</A.Description>
-              </Hds::Alert>
-            "}}}
-            @language="handlebars"
-          />
-        </PreviewBlock>
-        <h2 id="example-section">Example Section</h2>
-        <p>This section is below the fold so I can demo the link to hash working
-          properly</p> --}}
       </div>
       <InPageNav as |I|>
-        <I.Link @section="#how-to-use" @depth={{1}}>How to usue this component</I.Link>
-        <I.Link @section="#type" @depth={{2}}>type</I.Link>
-        <I.Link @section="#example-section" @depth={{1}}>Example section</I.Link>
+        <I.Link @section="#component-api" @depth={{1}}>Component API</I.Link>
       </InPageNav>
     </div>
   </T.Panel>

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -83,7 +83,7 @@
     "webpack": "^5.75.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -63,6 +63,7 @@
     "ember-source": "~4.11.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.6.0",
+    "ember-truth-helpers": "^3.1.1",
     "ember-try": "^2.0.0",
     "ember-url-hash-polyfill": "^1.0.8",
     "eslint": "^7.32.0",

--- a/documentation/tests/integration/components/component-api-test.js
+++ b/documentation/tests/integration/components/component-api-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | ComponentApi', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the api spec', async function (assert) {
+    await render(hbs`
+      <ComponentApi
+        @name="text"
+        @type="string"
+        @description="The text that serves as the description" 
+      />
+    `);
+
+    assert.dom('.doc-componentApi-name dd').hasText('text');
+    assert.dom('.doc-componentApi-type dd').hasText('string');
+    assert
+      .dom('.doc-componentApi-description dd')
+      .hasText('The text that serves as the description');
+
+    assert.dom('.doc-componentApi-values').doesNotExist();
+    assert.dom('.doc-componentApi-default').doesNotExist();
+  });
+
+  test('it renders the default when provided if there are no values', async function (assert) {
+    await render(hbs`
+      <ComponentApi
+        @name="text"
+        @type="string"
+        @default="foo"
+      />
+    `);
+
+    assert.dom('.doc-componentApi-default dd').hasText('foo');
+
+    await render(hbs`
+      <ComponentApi
+        @name="type"
+        @type="string"
+        @default="neutral"
+        @values={{array "success" "neutral" "warning" "critical"}}
+      />
+    `);
+
+    assert.dom('.doc-componentApi-default dd').doesNotExist();
+    assert.dom('.doc-componentApi-values dd').exists();
+
+    const values = await findAll('.doc-componentApi-values > dd > .hds-badge');
+
+    assert.strictEqual(values.length, 4);
+    assert.dom(values[0]).hasText('success');
+    assert.dom(values[0]).hasClass('hds-badge--type-filled');
+    assert.dom(values[1]).hasText('neutral');
+    assert.dom(values[1]).hasClass('hds-badge--type-inverted');
+    assert.dom(values[2]).hasText('warning');
+    assert.dom(values[2]).hasClass('hds-badge--type-filled');
+    assert.dom(values[3]).hasText('critical');
+    assert.dom(values[3]).hasClass('hds-badge--type-filled');
+  });
+});

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -38,8 +38,12 @@
   "devDependencies": {
     "@babel/core": "^7.17.0",
     "@babel/eslint-parser": "^7.18.2",
+    "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/plugin-proposal-decorators": "^7.17.0",
+    "@babel/plugin-proposal-json-strings": "^7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@babel/preset-typescript": "^7.21.0",
     "@embroider/addon-dev": "^3.0.0",
@@ -60,7 +64,7 @@
     "rollup": "^2.77.3",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-scss": "^4.0.0",
-    "rollup-plugin-ts": "3.0.2",
+    "rollup-plugin-ts": "3.2.0",
     "sass": "^1.60.0",
     "typescript": "^4.7.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7032,7 +7032,7 @@ ember-tracked-storage-polyfill@1.0.0, ember-tracked-storage-polyfill@^1.0.0:
     ember-cli-babel "^7.26.3"
     ember-cli-htmlbars "^5.7.1"
 
-ember-truth-helpers@^3.0.0:
+ember-truth-helpers@^3.0.0, ember-truth-helpers@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz#434715926d72bcc63b8a115dec09745fda4474dc"
   integrity sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,10 +2243,10 @@
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
 
-"@mdn/browser-compat-data@^4.1.16":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz#1fead437f3957ceebe2e8c3f46beccdb9bc575b8"
-  integrity sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==
+"@mdn/browser-compat-data@^5.2.33":
+  version "5.2.60"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.2.60.tgz#15838518cbff7ce0db94d4eff62e6ec9b5ce3a9b"
+  integrity sha512-HbULfvqZLvcjqjvXjQKpFPts6pS4awUa++0j8UukBPwDMLQYvDDbZnl/CQTjFv3cGGaoJS5A1aHLgxP9d/4SMw==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -2303,13 +2303,22 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rollup/pluginutils@^4.1.1", "@rollup/pluginutils@^4.2.1":
+"@rollup/pluginutils@^4.1.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
   integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
   dependencies:
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
+
+"@rollup/pluginutils@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
 
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
@@ -2620,6 +2629,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.33"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz#de35d30a9d637dc1450ad18dd583d75d5733d543"
@@ -2776,10 +2790,15 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.3.tgz#5798ecf1bec94eaa64db39ee52808ec0693315aa"
   integrity sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==
 
-"@types/semver@^7.3.12", "@types/semver@^7.3.9":
+"@types/semver@^7.3.12":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
+"@types/semver@^7.3.13":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/serve-static@*":
   version "1.15.1"
@@ -4751,34 +4770,23 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist-generator@^1.0.66:
-  version "1.0.66"
-  resolved "https://registry.yarnpkg.com/browserslist-generator/-/browserslist-generator-1.0.66.tgz#14f3f2cbf09e9a82e7c53a62f8cc18ce6c35eca3"
-  integrity sha512-aFDax4Qzh29DdyhHQBD2Yu2L5OvaDnvYFMbmpLrLwwaNK4H6dHEhC/Nxv93/+mfAA+a/t94ln0P2JZvHO6LZDA==
+browserslist-generator@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/browserslist-generator/-/browserslist-generator-2.0.3.tgz#1fe3c822188f8e689d4f7ef228ec634e8cc3689b"
+  integrity sha512-3j8ogwvlBpOEDR3f5n1H2n5BWXqHPWi/Xm8EC1DPJy5BWl4WkSFisatBygH/L9AEmg0MtOfcR1QnMuM9XL28jA==
   dependencies:
-    "@mdn/browser-compat-data" "^4.1.16"
+    "@mdn/browser-compat-data" "^5.2.33"
     "@types/object-path" "^0.11.1"
-    "@types/semver" "^7.3.9"
+    "@types/semver" "^7.3.13"
     "@types/ua-parser-js" "^0.7.36"
-    browserslist "4.20.2"
-    caniuse-lite "^1.0.30001328"
-    isbot "3.4.5"
+    browserslist "^4.21.5"
+    caniuse-lite "^1.0.30001450"
+    isbot "^3.6.5"
     object-path "^0.11.8"
-    semver "^7.3.7"
-    ua-parser-js "^1.0.2"
+    semver "^7.3.8"
+    ua-parser-js "^1.0.33"
 
-browserslist@4.20.2:
-  version "4.20.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
-  integrity sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
-  dependencies:
-    caniuse-lite "^1.0.30001317"
-    electron-to-chromium "^1.4.84"
-    escalade "^3.1.1"
-    node-releases "^2.0.2"
-    picocolors "^1.0.0"
-
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.20.4, browserslist@^4.21.3, browserslist@^4.21.5:
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.21.3, browserslist@^4.21.5:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
   integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
@@ -4787,6 +4795,16 @@ browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.20.4, browserslist@^4
     electron-to-chromium "^1.4.284"
     node-releases "^2.0.8"
     update-browserslist-db "^1.0.10"
+
+browserslist@^4.21.4:
+  version "4.21.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.7.tgz#e2b420947e5fb0a58e8f4668ae6e23488127e551"
+  integrity sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==
+  dependencies:
+    caniuse-lite "^1.0.30001489"
+    electron-to-chromium "^1.4.411"
+    node-releases "^2.0.12"
+    update-browserslist-db "^1.0.11"
 
 bser@2.1.1:
   version "2.1.1"
@@ -4949,10 +4967,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001328, caniuse-lite@^1.0.30001449:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449:
   version "1.0.30001469"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz#3dd505430c8522fdc9f94b4a19518e330f5c945a"
   integrity sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==
+
+caniuse-lite@^1.0.30001450, caniuse-lite@^1.0.30001489:
+  version "1.0.30001492"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
+  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5298,12 +5321,12 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-compatfactory@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/compatfactory/-/compatfactory-1.0.1.tgz#a5940f1d734b86c02bb818a67a412d4c306ccaf4"
-  integrity sha512-hR9u0HSZTKDNNchPtMHg6myeNx0XO+av7UZIJPsi4rPALJBHi/W5Mbwi19hC/xm6y3JkYpxVYjTqnSGsU5X/iw==
+compatfactory@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/compatfactory/-/compatfactory-2.0.9.tgz#98ccc78c7cac723ce05db0b7d9dae41b61407d7a"
+  integrity sha512-fvO+AWcmbO7P1S+A3mwm3IGr74eHMeq5ZLhNhyNQc9mVDNHT4oe0Gg0ksdIFFNXLK7k7Z/TYcLAUSQdRgh1bsA==
   dependencies:
-    helpertypes "^0.0.18"
+    helpertypes "^0.0.19"
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -5995,10 +6018,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.284, electron-to-chromium@^1.4.84:
+electron-to-chromium@^1.4.284:
   version "1.4.340"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.340.tgz#3a6d7414c1fc2dbf84b6f7af3ec24270606c85b8"
   integrity sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg==
+
+electron-to-chromium@^1.4.411:
+  version "1.4.417"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.417.tgz#a0c7eb992e68287fa50c8da5a5238b01f20b9a82"
+  integrity sha512-8rY8HdCxuSVY8wku3i/eDac4g1b4cSbruzocenrqBlzqruAZYHjQCHIjC66dLR9DXhEHTojsC4EjhZ8KmzwXqA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -7549,7 +7577,7 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
-estree-walker@^2.0.1:
+estree-walker@^2.0.1, estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -8841,10 +8869,10 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   dependencies:
     rsvp "~3.2.1"
 
-helpertypes@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.18.tgz#fd2bf5d3351cc7d80f7876732361d3adba63e5b4"
-  integrity sha512-XRhfbSEmR+poXUC5/8AbmYNJb2riOT6qPzjGJZr0S9YedHiaY+/tzPYzWMUclYMEdCYo/1l8PDYrQFCj02v97w==
+helpertypes@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/helpertypes/-/helpertypes-0.0.19.tgz#6f8cb18e4e1fad73dc103b98e624ac85cb06a720"
+  integrity sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -9580,10 +9608,10 @@ isbinaryfile@^5.0.0:
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.0.tgz#034b7e54989dab8986598cbcea41f66663c65234"
   integrity sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==
 
-isbot@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/isbot/-/isbot-3.4.5.tgz#69554585b725238692d9cc41d9a842c5b37fa33d"
-  integrity sha512-+KD6q1BBtw0iK9aGBGSfxJ31/ZgizKRjhm8ebgJUBMx0aeeQuIJ1I72beCoIrltIZGrSm4vmrxRxrG5n1aUTtw==
+isbot@^3.6.5:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/isbot/-/isbot-3.6.10.tgz#7b66334e81794f0461794debb567975cf08eaf2b"
+  integrity sha512-+I+2998oyP4oW9+OTQD8TS1r9P6wv10yejukj+Ksj3+UR5pUhsZN3f8W7ysq0p1qxpOVNbl5mCuv0bCaF8y5iQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -10277,12 +10305,12 @@ magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-magic-string@^0.26.2:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.7.tgz#caf7daf61b34e9982f8228c4527474dac8981d6f"
-  integrity sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
   dependencies:
-    sourcemap-codec "^1.4.8"
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 magic-string@^0.30.0:
   version "0.30.0"
@@ -10842,7 +10870,12 @@ node-notifier@^10.0.0:
     uuid "^8.3.2"
     which "^2.0.2"
 
-node-releases@^2.0.2, node-releases@^2.0.8:
+node-releases@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.12.tgz#35627cc224a23bfb06fb3380f2b3afaaa7eb1039"
+  integrity sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==
+
+node-releases@^2.0.8:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
@@ -12298,21 +12331,21 @@ rollup-plugin-scss@^4.0.0:
   dependencies:
     rollup-pluginutils "^2.3.3"
 
-rollup-plugin-ts@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-ts/-/rollup-plugin-ts-3.0.2.tgz#ee1a3f9ffe202ceff0b4d2f725fa268fa0c921bf"
-  integrity sha512-67qi2QTHewhLyKDG6fX3jpohWpmUPPIT/xJ7rsYK46X6MqmoWy64Ti0y8ygPfLv8mXDCdRZUofM3mTxDfCswRA==
+rollup-plugin-ts@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-ts/-/rollup-plugin-ts-3.2.0.tgz#d15c985d153e7b18adeb37c8bb6b39bc93655c8a"
+  integrity sha512-KkTLVifkUexEiAXS9VtSjDrjKr0TyusmNJpb2ZTAzI9VuPumSu4AktIaVNnwv70iUEitHwZtET7OAM+5n1u1tg==
   dependencies:
-    "@rollup/pluginutils" "^4.2.1"
+    "@rollup/pluginutils" "^5.0.2"
     "@wessberg/stringutil" "^1.0.19"
     ansi-colors "^4.1.3"
-    browserslist "^4.20.4"
-    browserslist-generator "^1.0.66"
-    compatfactory "^1.0.1"
+    browserslist "^4.21.4"
+    browserslist-generator "^2.0.1"
+    compatfactory "^2.0.9"
     crosspath "^2.0.0"
-    magic-string "^0.26.2"
-    ts-clone-node "^1.0.0"
-    tslib "^2.4.0"
+    magic-string "^0.27.0"
+    ts-clone-node "^2.0.4"
+    tslib "^2.4.1"
 
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.3, rollup-pluginutils@^2.8.1:
   version "2.8.2"
@@ -13648,12 +13681,12 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==
 
-ts-clone-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ts-clone-node/-/ts-clone-node-1.0.0.tgz#aaffa5478cf303471cec9c3c8169e117a0f87614"
-  integrity sha512-/cDYbr2HAXxFNeTT41c/xs/2bhLJjqnYheHsmA3AoHSt+n4JA4t0FL9Lk5O8kWnJ6jeB3kPcUoXIFtwERNzv6Q==
+ts-clone-node@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/ts-clone-node/-/ts-clone-node-2.0.4.tgz#18f26c2d490f65c6925f7a841a44ca2476da3eee"
+  integrity sha512-eG6FAgmQsenhIJOIFhUcO6yyYejBKZIKcI3y21jiQmIOrth5pD6GElyPAyeihbPSyBs3u/9PVNXy+5I7jGy8jA==
   dependencies:
-    compatfactory "^1.0.1"
+    compatfactory "^2.0.9"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -13664,6 +13697,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.4.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -13778,10 +13816,10 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-ua-parser-js@^1.0.2:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.34.tgz#b33f41c415325839f354005d25a2f588be296976"
-  integrity sha512-K9mwJm/DaB6mRLZfw6q8IMXipcrmuT6yfhYmwhAkuh+81sChuYstYA+znlgaflUPaYUa3odxKPKGw6Vw/lANew==
+ua-parser-js@^1.0.33:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
+  integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -13919,6 +13957,14 @@ update-browserslist-db@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
   integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
+update-browserslist-db@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
+  integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"


### PR DESCRIPTION
### :hammer_and_wrench: Description
I started working on the code section for the list item docs decided to split this component out into it's own PR. It's based off the [design system docs](https://helios.hashicorp.design/components/badge?tab=code#component-api) but not trying to be an exact clone (re: text size & colors). We don't have the blue available in the badges so I'm curious what color you prefer? I think neutral is fine.

### :camera_flash: Screenshots

Here are the badges in highlight colors
<img width="1667" alt="Screenshot 2023-06-01 at 2 59 28 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/407ac63c-3d07-4d67-9ecf-a32844527064">


<!-- What code changed, and why? -->
Here are the badges in neutral colors
<img width="1667" alt="Screenshot 2023-06-01 at 2 59 09 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/4a25fd69-150a-4d6a-8bfe-66134c85d08b">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
