### PR TITLE
Update list-item element and background-color

### DIFF
--- a/.changeset/odd-fishes-smoke.md
+++ b/.changeset/odd-fishes-smoke.md
@@ -1,0 +1,6 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update list-item component to use `li` element
+Update list-item to have default background color of surface-primary

--- a/documentation/tests/integration/components/list-item-test.js
+++ b/documentation/tests/integration/components/list-item-test.js
@@ -21,9 +21,9 @@ module('Integration | Component | cut/list-item', function (hooks) {
   });
 
   // Static
-  test('it should render a <div> if no @href, @onClick or @route is passed (default)', async function (assert) {
+  test('it should render a <li> if no @href, @onClick or @route is passed (default)', async function (assert) {
     await render(hbs`<Cut::ListItem id="test-list-item" />`);
-    assert.dom('#test-list-item').hasTagName('div');
+    assert.dom('#test-list-item').hasTagName('li');
   });
 
   // Dynamic
@@ -63,13 +63,13 @@ module('Integration | Component | cut/list-item', function (hooks) {
     assert.dom('#test-list-item .active').doesNotHaveAttribute('rel');
   });
 
-  test('it should spread all the attributes passed to the <div> element', async function (assert) {
+  test('it should spread all the attributes passed to the <li> element', async function (assert) {
     await render(
       hbs`<Cut::ListItem id="test-list-item" class="my-class" data-test1 data-test2="test" />`
     );
-    assert.dom('div#test-list-item').hasClass('my-class');
-    assert.dom('div#test-list-item').hasAttribute('data-test1');
-    assert.dom('div#test-list-item').hasAttribute('data-test2', 'test');
+    assert.dom('li#test-list-item').hasClass('my-class');
+    assert.dom('li#test-list-item').hasAttribute('data-test1');
+    assert.dom('li#test-list-item').hasAttribute('data-test2', 'test');
   });
 
   test('it should yield the content of the List item element', async function (assert) {

--- a/toolkit/src/components/cut/list-item/index.hbs
+++ b/toolkit/src/components/cut/list-item/index.hbs
@@ -1,7 +1,7 @@
 {{!
   Copyright (c) HashiCorp, Inc.
 }}
-<div
+<li
   class='cut-list-item hds-surface-primary
     {{if (or @route @href @onClick) "hds-surface-mid" "hds-surface-base"}}'
   ...attributes
@@ -32,4 +32,4 @@
       ActionGeneric=(component 'cut/list-item/action-generic')
     )
   }}
-</div>
+</li>

--- a/toolkit/src/components/cut/list-item/index.hbs
+++ b/toolkit/src/components/cut/list-item/index.hbs
@@ -1,10 +1,14 @@
 {{!
   Copyright (c) HashiCorp, Inc.
 }}
-<div class="cut-list-item {{if (or @route @href @onClick) 'hds-surface-mid' 'hds-surface-base'}}" ...attributes>
+<div
+  class='cut-list-item hds-surface-primary
+    {{if (or @route @href @onClick) "hds-surface-mid" "hds-surface-base"}}'
+  ...attributes
+>
   {{#if (or @route @href @onClick)}}
     <Hds::Interactive
-      class="cut-list-item__content-container active"
+      class='cut-list-item__content-container active'
       @href={{this.href}}
       @isRouteExternal={{@isRouteExternal}}
       @route={{this.route}}
@@ -14,16 +18,18 @@
       {{on 'click' this.onClickAction}}
       ...attributes
     >
-      {{yield (hash Content=(component "cut/list-item/content"))}}
+      {{yield (hash Content=(component 'cut/list-item/content'))}}
     </Hds::Interactive>
 
   {{else}}
-    {{yield (hash Content=(component "cut/list-item/content"))}}
+    {{yield (hash Content=(component 'cut/list-item/content'))}}
   {{/if}}
 
   {{yield
-    (hash ActionButton=(component "hds/button" size="small")
-      ActionDropdown=(component "hds/dropdown")
-      ActionGeneric=(component "cut/list-item/action-generic")
-    )}}
+    (hash
+      ActionButton=(component 'hds/button' size='small')
+      ActionDropdown=(component 'hds/dropdown')
+      ActionGeneric=(component 'cut/list-item/action-generic')
+    )
+  }}
 </div>

--- a/toolkit/src/styles/components/list-item.scss
+++ b/toolkit/src/styles/components/list-item.scss
@@ -44,12 +44,12 @@ button.cut-list-item__content-container {
     position: absolute;
     inset: 0;
     border-radius: 6px;
-    content: "";
+    content: '';
     z-index: -1;
   }
   &.active:focus-visible,
   &.active:focus {
-    &:before{
+    &:before {
       outline: 3px solid var(--token-color-focus-action-external);
       outline-offset: 1px;
     }


### PR DESCRIPTION
### :hammer_and_wrench: Description
**Note: floating deps are failing but are addressed in #26. I won't be merging this until #26 gets in.**

<!-- What code changed, and why? -->
- Updates the `<Cut::ListItem />` to use a `li` for it's containing element
- Update the `<Cut::ListItem />` to have a `surface-primary` background-color by default so that it's not transparent. ([see docs](https://www.figma.com/file/SenC8kTQNUJKCvOvcL8WPu/Consul-Component-Library?type=design&node-id=640-83276&t=7NjWWYHm7kEvePlA-0))

### :camera_flash: Screenshots

**Before:**
<img width="1667" alt="Screenshot 2023-06-05 at 8 55 46 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/b5493b99-a9a0-4199-b111-9c2f86d6ebf1">

**After:**
<img width="1667" alt="Screenshot 2023-06-05 at 9 00 26 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/14bdd8ab-4942-48ae-9d38-d3d484b4ce28">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
You may also see the [latest of the in-progress docs](https://consul-ui-toolkit-documentation-6ghtntzm9-hashicorp.vercel.app/components/list-item) that has these commits as well.

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
