### PR TITLE
Upgrade @hashicorp/design-system-components to 2.7.0

### DIFF
--- a/.changeset/healthy-otters-repair.md
+++ b/.changeset/healthy-otters-repair.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Upgrade @hashicorp/design-system-components.

--- a/documentation/app/components/list-item/index.hbs
+++ b/documentation/app/components/list-item/index.hbs
@@ -182,6 +182,13 @@
   </Cut::ListItem>
   <Cut::ListItem as |L|>
     <L.Content>Service c</L.Content>
+    <L.ActionGeneric>
+      <Hds::Link::Standalone
+        @href="#"
+        @text="2 Permissions"
+        @icon="docs-link"
+      />
+    </L.ActionGeneric>
   </Cut::ListItem>
   <Cut::ListItem as |L|>
     <L.Content>Service d</L.Content>
@@ -381,13 +388,13 @@
     {{#if (eq item.type this.cutServiceListItems.Service)}}
       <Cut::ListItem::Service
         @isHrefExternal={{false}}
-        @href='#'
+        @href="#"
         @service={{item}}
       />
     {{else if (eq item.type this.cutServiceListItems.ServiceInstance)}}
       <Cut::ListItem::ServiceInstance
         @isHrefExternal={{false}}
-        @href='#'
+        @href="#"
         @service={{item}}
       />
     {{/if}}

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -30,7 +30,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@hashicorp/consul-ui-toolkit": "^0.1.0",
-    "@hashicorp/design-system-components": "^2.2.0",
+    "@hashicorp/design-system-components": "^2.7.0",
     "@hashicorp/ember-flight-icons": "^3.0.2",
     "@types/qunit": "latest",
     "@typescript-eslint/eslint-plugin": "^5.2.0",

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",
+    "ember-composable-helpers": "^5.0.0",
     "ember-concurrency": "^2.3.7",
-    "ember-concurrency-decorators": "^2.0.3",
-    "ember-composable-helpers": "^5.0.0"
+    "ember-concurrency-decorators": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
@@ -48,8 +48,7 @@
     "@babel/plugin-syntax-decorators": "^7.17.0",
     "@babel/preset-typescript": "^7.21.0",
     "@embroider/addon-dev": "^3.0.0",
-    "@hashicorp/design-system-components": "^2.2.0",
-    "@hashicorp/design-system-tokens": "^1.5.0",
+    "@hashicorp/design-system-components": "^2.7.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@types/ember": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,14 +2101,14 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
   integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
-"@hashicorp/design-system-components@^2.2.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-components/-/design-system-components-2.3.0.tgz#22b1c4753df36b1e7cf35950691717cbbcbabaec"
-  integrity sha512-V3l0e0NuXjeqCTc+AEHG6YBb1dFMUXDXSWd3vFVc1tYu2fTHWs5Z6sduFAlwW7BelUfLqutoIYxtAMMJ4fRxvQ==
+"@hashicorp/design-system-components@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-components/-/design-system-components-2.7.0.tgz#d461374ddaad7564dadfb4b996c580abe1a1aecf"
+  integrity sha512-hoZTgzP9vP6ft/2GsJeaTyhStVsBJn1qV7FUxwmy6zSR1Gose0aHDR4XtJFAhJd0UAw+Gjaa/z41ihclW6rRWw==
   dependencies:
     "@ember/render-modifiers" "^2.0.5"
     "@hashicorp/design-system-tokens" "^1.5.0"
-    "@hashicorp/ember-flight-icons" "^3.0.2"
+    "@hashicorp/ember-flight-icons" "^3.0.5"
     dialog-polyfill "^0.5.6"
     ember-a11y-refocus "^3.0.2"
     ember-auto-import "^2.6.0"
@@ -2141,10 +2141,25 @@
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.1.0"
 
+"@hashicorp/ember-flight-icons@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-3.0.5.tgz#ed30ad3cc4a00c7b376438d51a19a5ae5b4891b8"
+  integrity sha512-N0mQZS3a7mk+4AZNbaRyCqE2wqcAchpO6k5XTypCPKks6ZgpveVQFoLfd02XNw3MSJ5h2gm6lLckAxZaCDNl4Q==
+  dependencies:
+    "@hashicorp/flight-icons" "^2.13.1"
+    ember-auto-import "^2.6.0"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.1.0"
+
 "@hashicorp/flight-icons@^2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.12.0.tgz#48bc21f21678668ffe9147b181a2991d8b151fc7"
   integrity sha512-PhjTTHCjoq4EJirifbxLxnxXnCRf1NUAYZ1WnFW8i0yOmmax6fgjsJRPlf0VIGsR8R7isFpjuy6gJ5c7mNhE0w==
+
+"@hashicorp/flight-icons@^2.13.1":
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.13.1.tgz#bcf1adce364282845c6e1e89ed892133d44579c3"
+  integrity sha512-f9Sg/5KOMsE7o+Im5coVuenhRkKva7w8nNxjfWLP/iSZVHy2uVHJvhPOcibAAeam1Mnbe7k+sHV6liOtOMKIBA==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
- Upgrade @hashicorp/design-system-components to 2.7.0
- Remove dependency on design-system-tokens as we get it implicitly through design-system-components. We should only have to install it directly if we aren't using the component library.

### :camera_flash: Screenshots
Styles still work
<img width="1804" alt="Screenshot 2023-06-21 at 12 25 45 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/aa29ad10-fccf-4855-804b-bc40b7ce3a58">
<img width="1804" alt="Screenshot 2023-06-21 at 12 26 00 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/fd874763-5267-4ef4-a3d7-9844727624bd">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
