### PR TITLE
CC-5328: add service-instance list item docs

### DIFF
--- a/.changeset/chilled-experts-taste.md
+++ b/.changeset/chilled-experts-taste.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update service instance list item type styling

--- a/documentation/app/components/component-api/index.hbs
+++ b/documentation/app/components/component-api/index.hbs
@@ -8,22 +8,24 @@
     <dd><Hds::Badge @text={{@name}} @type="inverted" /></dd>
   </div>
 
-  {{#if @type}}
+  <div class="doc-componentApi-type-required-group">
     <div class="doc-componentApi-type">
-      <dt>Type</dt>
-      <dd class="hds-font-family-mono-code">{{@type}}</dd>
+      {{#if @type}}
+        <dt>Type</dt>
+        <dd class="hds-font-family-mono-code">{{@type}}</dd>
+      {{/if}}
     </div>
-  {{/if}}
+
+    {{#if @isRequired}}
+      <Hds::Badge @text="Required" class="doc-componentApi-required" />
+    {{/if}}
+  </div>
 
   {{#if (and @default (not @values))}}
     <div class="doc-componentApi-default">
       <dt>Default</dt>
       <dd><Hds::Badge @text={{@default}} @type="inverted" /></dd>
     </div>
-  {{/if}}
-
-  {{#if @isRequired}}
-    <Hds::Badge @text="Required" class="doc-componentApi-required" />
   {{/if}}
 
   {{#if @values}}

--- a/documentation/app/controllers/components/service-instance-list-item.js
+++ b/documentation/app/controllers/components/service-instance-list-item.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
+import Controller from '@ember/controller';
+import { SERVICE_GATEWAY_TYPE } from '@hashicorp/consul-ui-toolkit/utils/service-list-item';
+
+export default class ServiceInstanceListItem extends Controller {
+  get serviceListItem() {
+    return {
+      name: 'Service (Ingress Gateway)',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 5,
+            warning: 0,
+            critical: 0,
+          },
+        },
+        connectedWithGateway: true,
+        kind: SERVICE_GATEWAY_TYPE.IngressGateway,
+        upstreamCount: 5,
+        tags: ['monitor', 'array', 'monitor'],
+      },
+    };
+  }
+
+  get healthyPlainService() {
+    return {
+      name: 'Plain Healthy Service',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 3,
+            warning: 0,
+            critical: 0,
+          },
+        },
+        externalSource: 'consul',
+        instanceCount: 3,
+        tags: ['consul', 'array', 'monitor'],
+      },
+    };
+  }
+
+  get failingTerminatingGateway() {
+    return {
+      name: 'Service (terminating gateway): Failed checks',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 4,
+            warning: 0,
+            critical: 1,
+          },
+        },
+        kind: SERVICE_GATEWAY_TYPE.TerminatingGateway,
+        linkedServiceCount: 6,
+        externalSource: 'vault',
+      },
+    };
+  }
+
+  get mtlsSamenessGroupService() {
+    return {
+      name: 'Service: imported, with sameness group, permissive mTLS',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 2,
+            warning: 1,
+            critical: 0,
+          },
+        },
+        instanceCount: 8,
+        isImported: true,
+        samenessGroup: 'group-1',
+        isPermissiveMTls: true,
+      },
+    };
+  }
+
+  get healthyServiceInstance() {
+    return {
+      name: 'Service instance: All Healthy',
+      metadata: {
+        healthCheck: {
+          node: {
+            success: 5,
+            warning: 0,
+            critical: 0,
+          },
+          service: {
+            success: 2,
+            warning: 0,
+            critical: 0,
+          },
+        },
+        tags: ['tag', 'service'],
+        servicePortAddress: '8.8.8.8:8000',
+        serviceSocketPath: '/qui/asperiores/quis',
+        node: 'node',
+        externalSource: 'kubernetes',
+      },
+    };
+  }
+
+  get failingServiceInstance() {
+    return {
+      name: 'Service instance: Failed checks, service socket, no tags, no node name',
+      metadata: {
+        healthCheck: {
+          node: {
+            success: 5,
+            warning: 1,
+            critical: 2,
+          },
+          service: {
+            success: 9,
+            warning: 0,
+            critical: 0,
+          },
+        },
+        tags: [],
+        servicePortAddress: '',
+        serviceSocketPath: '/qui/asperiores/quis',
+        node: null,
+      },
+    };
+  }
+}

--- a/documentation/app/router.js
+++ b/documentation/app/router.js
@@ -22,5 +22,6 @@ Router.map(function () {
     this.route('list-item');
     this.route('list-item-template');
     this.route('service-list-item');
+    this.route('service-instance-list-item');
   });
 });

--- a/documentation/app/styles/components/component-api.scss
+++ b/documentation/app/styles/components/component-api.scss
@@ -4,8 +4,8 @@
 
 .doc-componentApi {
   display: grid;
-  grid-template-columns: 1fr 1fr auto;
-  grid-template-areas: "name type required";
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas: "name type";
   grid-auto-flow: row;
   gap: 1rem;
   padding: 1.5rem 1rem;
@@ -28,13 +28,13 @@
     grid-area: name;
   }
 
-  .doc-componentApi-type {
+  .doc-componentApi-type-required-group {
     grid-area: type;
+    display: flex;
+    justify-content: space-between;
   }
 
   .doc-componentApi-required {
-    grid-area: required;
-    justify-self: end;
     align-self: start;
   }
 

--- a/documentation/app/templates/application.hbs
+++ b/documentation/app/templates/application.hbs
@@ -31,6 +31,10 @@
           @text="Service List Item"
           @route="components.service-list-item"
         />
+        <S.Link
+          @text="Service Instance List Item"
+          @route="components.service-instance-list-item"
+        />
       </Hds::SideNav::List>
     </:body>
   </Hds::SideNav>

--- a/documentation/app/templates/components/service-instance-list-item.hbs
+++ b/documentation/app/templates/components/service-instance-list-item.hbs
@@ -1,0 +1,270 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+}}
+
+<PageHeader
+  @title="Service Instance List Item"
+  @figma="https://www.figma.com/file/SenC8kTQNUJKCvOvcL8WPu/Consul-Component-Library?node-id=642%3A89719&mode=dev"
+  @github="https://github.com/hashicorp/consul-ui-toolkit/tree/main/toolkit/src/components/cut/list-item/service-instance"
+  @status="development"
+>
+  The Service Instance List Item is a wrapper of the List Item and List Item
+  Template components that takes data from a Service Instance and generates a
+  List Item with the appropriate information and formatting.
+</PageHeader>
+<Hds::Tabs as |T|>
+  <T.Tab>About</T.Tab>
+  <T.Tab>Code</T.Tab>
+  <T.Panel>
+    <div class="doc-Page">
+      <div class="doc-Page-content">
+        <h2 id="about">About</h2>
+        <p>The Service Instance List Item is a wrapper around the
+          <Hds::Link::Inline @route="components.list-item">List Item</Hds::Link::Inline>
+          and
+          <Hds::Link::Inline @route="components.list-item-template">List Item
+            Template</Hds::Link::Inline>, and is used to make it easier to build
+          list items for Service Instances across the two Consul UI
+          applications.</p>
+        <Cut::ListItem::ServiceInstance
+          @service={{this.healthyServiceInstance}}
+        />
+
+        <h2 id="examples">Examples</h2>
+        <p>The following are some examples of different Service Instance List
+          Items and their corresponding Service Instance object. For the full
+          API, visit the Code tab.</p>
+
+        <PreviewBlock as |P|>
+          <P.Preview>
+            <Cut::ListItem::ServiceInstance
+              @service={{this.healthyServiceInstance}}
+            />
+          </P.Preview>
+          <P.Code
+            @code={{{"
+            /* 
+              Example service object
+              {
+                name: 'Service instance: All Healthy',
+                metadata: {
+                  healthCheck: {
+                    node: {
+                      success: 5,
+                      warning: 0,
+                      critical: 0,
+                    },
+                    service: {
+                      success: 2,
+                      warning: 0,
+                      critical: 0,
+                    },
+                  },
+                  tags: ['tag', 'service'],
+                  servicePortAddress: '8.8.8.8:8000',
+                  serviceSocketPath: '/qui/asperiores/quis',
+                  node: 'node',
+                  externalSource: 'kubernetes',
+                },
+              }
+            */
+
+            <Cut::ListItem::ServiceInstance @service={{this.healthyServiceInstance}} />
+          "}}}
+          />
+        </PreviewBlock>
+
+        <PreviewBlock as |P|>
+          <P.Preview>
+            <Cut::ListItem::ServiceInstance
+              @service={{this.failingServiceInstance}}
+            />
+          </P.Preview>
+          <P.Code
+            @code={{{"
+            /* 
+              Example service object
+              {
+                name: 'Service instance: Failed checks, service socket, no tags, no node name',
+                metadata: {
+                  healthCheck: {
+                    node: {
+                      success: 5,
+                      warning: 1,
+                      critical: 2,
+                    },
+                    service: {
+                      success: 9,
+                      warning: 0,
+                      critical: 0,
+                    },
+                  },
+                  tags: [],
+                  servicePortAddress: '',
+                  serviceSocketPath: '/qui/asperiores/quis',
+                  node: null,
+                },
+              }
+            */
+
+            <Cut::ListItem::ServiceInstance @service={{this.failingServiceInstance}} />
+          "}}}
+          />
+        </PreviewBlock>
+
+      </div>
+      <InPageNav as |I|>
+        <I.Link @section="#about">About</I.Link>
+        <I.Link @section="#examples">Examples</I.Link>
+      </InPageNav>
+    </div>
+
+  </T.Panel>
+  <T.Panel>
+    <div class="doc-Page">
+      <div class="doc-Page-content">
+        <h2 id="component-api">Component API</h2>
+        <p>The Service Instance List Item is composed with the List Item and the
+          List Item Template. It accepts all the arguments that the List Item
+          does. Visit the
+          <Hds::Link::Inline @route="components.list-item">List Item
+            documentation</Hds::Link::Inline>
+          to get full details on it's API.</p>
+
+        <h3 id="service">Service</h3>
+        <p>Aside from that, the Service Instance List Item accepts a Service
+          object that is composed of a
+          <CodeInline @code="service.name" />
+          and a
+          <CodeInline @code="service.metadata" />
+          object. We'll dive into the details below.</p>
+
+        <CodeBlock
+          @code={{{"
+          interface CutServiceInstance {
+            name?: string;
+            metadata: {
+              healthCheck: {
+                node?: HealthCheck;
+                service?: HealthCheck;
+              };
+              tags: string[];
+              servicePortAddress?: string;
+              serviceSocketPath?: string;
+              node?: string;
+              externalSource?: ExternalSource;
+              connectedWithProxy?: boolean;
+            };
+          }
+          "}}}
+        />
+
+        <ComponentApi
+          @name="service.name"
+          @isRequired={{true}}
+          @type="string"
+        />
+        <h3 id="metadata">Metadata</h3>
+        <p>The
+          <CodeInline @code="service.metadata" />
+          object on the service holds the details to display the significant
+          portion of the information about the service.</p>
+
+        <ComponentApi @name="service.metadata.tags" @type="string[]">
+          Used to display a list of tags for the Service Instance in the List
+          Item metadata.
+        </ComponentApi>
+
+        <ComponentApi
+          @name="service.metadata.externalSource"
+          @type="string"
+          @values={{array
+            "kubernetes"
+            "terraform"
+            "nomad"
+            "consul"
+            "consul-api-gateway"
+            "vault"
+            "aws"
+            "aws-iam"
+            "lambda"
+            "undefined"
+          }}
+          @default="undefined"
+        >
+          Used to display what the Service Instance was registered via in the
+          List Item metadata.
+        </ComponentApi>
+
+        <ComponentApi
+          @name="service.metadata.servicePortAddress"
+          @type="string"
+        >
+          Used to display the Service Instance IP and Port in the List Item
+          metadata.
+        </ComponentApi>
+
+        <ComponentApi @name="service.metadata.serviceSocketPath" @type="string">
+          Used to display the Service Instance Socket Path in the List Item
+          metadata.
+        </ComponentApi>
+
+        <ComponentApi @name="service.metadata.node" @type="string">
+          Used to display the associated Node name in the List Item metadata.
+        </ComponentApi>
+
+        <ComponentApi
+          @name="service.metadata.connectedWithProxy"
+          @type="boolean"
+          @default="false"
+        >
+          If this is
+          <CodeInline @code="true" />
+          then an icon with text displaying "in service mesh with proxy" display
+          in the List Item metadata.
+        </ComponentApi>
+
+        <h4 id="health-check">Health check</h4>
+        The
+        <CodeInline @code="service.metadata.healthCheck" />
+        property is an object that has two optional properties,
+        <CodeInline @code="node" />
+        and
+        <CodeInline @code="service" />, that hold the information about the node
+        and service instances' health check statuses respectively. The API for
+        the
+        <CodeInline @code="service.metadata.healthCheck.{node|service}" />
+        property is as follows.
+
+        <ComponentApi
+          @name="service.metadata.healthCheck.{node|service}.success"
+          @isRequired={{true}}
+          @type="number"
+        >The number of node/service health checks reporting a
+          <CodeInline @code="success" />
+          status.</ComponentApi>
+        <ComponentApi
+          @name="service.metadata.healthCheck.{node|service}.warning"
+          @isRequired={{true}}
+          @type="number"
+        >The number of node/service health checks reporting a
+          <CodeInline @code="warning" />
+          status.</ComponentApi>
+        <ComponentApi
+          @name="service.metadata.healthCheck.{node|service}.critical"
+          @isRequired={{true}}
+          @type="number"
+        >The number of node/service health checks reporting a
+          <CodeInline @code="critical" />
+          status.</ComponentApi>
+
+      </div>
+      <InPageNav as |I|>
+        <I.Link @section="#component-api">Component API</I.Link>
+        <I.Link @section="#service" @depth={{2}}>Service</I.Link>
+        <I.Link @section="#metadata" @depth={{2}}>Metadata</I.Link>
+        <I.Link @section="#health-check" @depth={{2}}>Health check</I.Link>
+      </InPageNav>
+    </div>
+  </T.Panel>
+</Hds::Tabs>

--- a/toolkit/src/components/cut/list-item/service-instance/index.ts
+++ b/toolkit/src/components/cut/list-item/service-instance/index.ts
@@ -9,18 +9,18 @@ import {
 } from '../../../../utils/service-list-item';
 
 export interface CutServiceInstance {
-  name: string | undefined;
+  name?: string;
   metadata: {
     healthCheck: {
-      node: HealthCheck | undefined;
-      service: HealthCheck | undefined;
+      node?: HealthCheck;
+      service?: HealthCheck;
     };
     tags: string[];
-    servicePortAddress: string | null;
-    serviceSocketPath: string | undefined;
-    node: string | undefined;
-    externalSource: ExternalSource | undefined;
-    connectedWithProxy: boolean | undefined;
+    servicePortAddress?: string;
+    serviceSocketPath?: string;
+    node?: string;
+    externalSource?: ExternalSource;
+    connectedWithProxy?: boolean;
   };
 }
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Add service instance list item docs, very similar to service list item docs. Realized that it may be good to switch the name of the `service` arg to `instance` but not part of this PR.

### :camera_flash: Screenshots

<img width="1804" alt="Screenshot 2023-07-04 at 4 51 38 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/4e149b04-68c5-48e4-b2e0-009792fdda08">
<img width="1804" alt="Screenshot 2023-07-04 at 4 51 34 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/8fc0b33c-cbf3-4822-aa54-685c787e0529">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
- [CC-5328](https://hashicorp.atlassian.net/browse/CC-5328)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [x] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-5328]: https://hashicorp.atlassian.net/browse/CC-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ