### PR TITLE
CC-6167: Export all types from an index file

### DIFF
--- a/.changeset/selfish-poets-share.md
+++ b/.changeset/selfish-poets-share.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': major
+---
+
+Update where types are declared and how they are exported

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -16,6 +16,7 @@
     "addon-main.cjs",
     "dist"
   ],
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup --config",
     "cleanup:local": "yalc installations clean @hashicorp/consul-ui-toolkit",
@@ -87,6 +88,7 @@
     "main": "addon-main.cjs",
     "app-js": {
       "./components/cut/copy-block/index.js": "./dist/_app_/components/cut/copy-block/index.js",
+      "./components/cut/copy-block/types.js": "./dist/_app_/components/cut/copy-block/types.js",
       "./components/cut/filter-bar/filter-group.js": "./dist/_app_/components/cut/filter-bar/filter-group.js",
       "./components/cut/filter-bar/filter/checkbox.js": "./dist/_app_/components/cut/filter-bar/filter/checkbox.js",
       "./components/cut/filter-bar/filter/checkmark.js": "./dist/_app_/components/cut/filter-bar/filter/checkmark.js",
@@ -100,6 +102,7 @@
       "./components/cut/filter-bar/sort-group.js": "./dist/_app_/components/cut/filter-bar/sort-group.js",
       "./components/cut/filter-bar/sort/checkmark.js": "./dist/_app_/components/cut/filter-bar/sort/checkmark.js",
       "./components/cut/filter-bar/sort/index.js": "./dist/_app_/components/cut/filter-bar/sort/index.js",
+      "./components/cut/filter-bar/types.js": "./dist/_app_/components/cut/filter-bar/types.js",
       "./components/cut/list-item/action-generic.js": "./dist/_app_/components/cut/list-item/action-generic.js",
       "./components/cut/list-item/content.js": "./dist/_app_/components/cut/list-item/content.js",
       "./components/cut/list-item/index.js": "./dist/_app_/components/cut/list-item/index.js",
@@ -109,16 +112,21 @@
       "./components/cut/list-item/service-instance/index.js": "./dist/_app_/components/cut/list-item/service-instance/index.js",
       "./components/cut/list-item/service/index.js": "./dist/_app_/components/cut/list-item/service/index.js",
       "./components/cut/list-item/template/index.js": "./dist/_app_/components/cut/list-item/template/index.js",
+      "./components/cut/list-item/types.js": "./dist/_app_/components/cut/list-item/types.js",
       "./components/cut/list/contents/empty.js": "./dist/_app_/components/cut/list/contents/empty.js",
       "./components/cut/list/contents/generic.js": "./dist/_app_/components/cut/list/contents/generic.js",
       "./components/cut/list/index.js": "./dist/_app_/components/cut/list/index.js",
       "./components/cut/list/pagination.js": "./dist/_app_/components/cut/list/pagination.js",
+      "./components/cut/list/types.js": "./dist/_app_/components/cut/list/types.js",
       "./components/cut/metadata/external-source/index.js": "./dist/_app_/components/cut/metadata/external-source/index.js",
       "./components/cut/metadata/health-check-badge-set/index.js": "./dist/_app_/components/cut/metadata/health-check-badge-set/index.js",
       "./components/cut/metadata/in-service-mesh/index.js": "./dist/_app_/components/cut/metadata/in-service-mesh/index.js",
       "./components/cut/metadata/tags/index.js": "./dist/_app_/components/cut/metadata/tags/index.js",
+      "./components/cut/metadata/types.js": "./dist/_app_/components/cut/metadata/types.js",
       "./components/cut/text-with-icon/index.js": "./dist/_app_/components/cut/text-with-icon/index.js",
+      "./components/cut/text-with-icon/types.js": "./dist/_app_/components/cut/text-with-icon/types.js",
       "./helpers/titlecase.js": "./dist/_app_/helpers/titlecase.js",
+      "./utils/index.js": "./dist/_app_/utils/index.js",
       "./utils/service-list-item.js": "./dist/_app_/utils/service-list-item.js"
     }
   },

--- a/toolkit/src/components/cut/copy-block/index.ts
+++ b/toolkit/src/components/cut/copy-block/index.ts
@@ -6,16 +6,9 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { timeout } from 'ember-concurrency';
 import { dropTask } from 'ember-concurrency-decorators';
+import { CopyBlockSignature } from 'src/types';
 
-export interface ComponentSignature {
-  Args: {
-    clipboardText: string;
-    timeout?: number;
-    onSuccess(): void;
-  };
-}
-
-export default class CopyBlockComponent extends Component<ComponentSignature> {
+export default class CopyBlockComponent extends Component<CopyBlockSignature> {
   @tracked isSuccessfullyCopied = false;
 
   get timeout() {

--- a/toolkit/src/components/cut/copy-block/types.ts
+++ b/toolkit/src/components/cut/copy-block/types.ts
@@ -1,0 +1,7 @@
+export interface CopyBlockSignature {
+  Args: {
+    clipboardText: string;
+    timeout?: number;
+    onSuccess(): void;
+  };
+}

--- a/toolkit/src/components/cut/copy-block/types.ts
+++ b/toolkit/src/components/cut/copy-block/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export interface CopyBlockSignature {
   Args: {
     clipboardText: string;

--- a/toolkit/src/components/cut/filter-bar/filter/checkbox.ts
+++ b/toolkit/src/components/cut/filter-bar/filter/checkbox.ts
@@ -3,24 +3,9 @@
  */
 
 import Component from '@glimmer/component';
-import { FilterConfig, ToggleArgs } from '..';
+import { FilterBarCheckboxSignature } from 'src/types';
 
-interface FilterBarCheckbox {
-  Args: {
-    filterName: string;
-    name: string;
-    value: unknown;
-    localConfig: FilterConfig;
-    toggle: (toggle: ToggleArgs) => void;
-    isChecked: (
-      localConfig: FilterConfig,
-      name: string,
-      value: unknown
-    ) => boolean;
-  };
-}
-
-export default class CheckboxComponent extends Component<FilterBarCheckbox> {
+export default class CheckboxComponent extends Component<FilterBarCheckboxSignature> {
   get isChecked() {
     return this.args.isChecked(
       this.args.localConfig,

--- a/toolkit/src/components/cut/filter-bar/filter/checkmark.ts
+++ b/toolkit/src/components/cut/filter-bar/filter/checkmark.ts
@@ -3,24 +3,9 @@
  */
 
 import Component from '@glimmer/component';
-import { FilterConfig, ToggleArgs } from '..';
+import { FilterBarCheckboxSignature } from 'src/types';
 
-interface FilterBarCheckbox {
-  Args: {
-    filterName: string;
-    name: string;
-    value: unknown;
-    localConfig: FilterConfig;
-    toggle: (toggle: ToggleArgs) => void;
-    isChecked: (
-      localConfig: FilterConfig,
-      name: string,
-      value: unknown
-    ) => boolean;
-  };
-}
-
-export default class CheckmarkComponent extends Component<FilterBarCheckbox> {
+export default class CheckmarkComponent extends Component<FilterBarCheckboxSignature> {
   get isChecked() {
     return this.args.isChecked(
       this.args.localConfig,

--- a/toolkit/src/components/cut/filter-bar/filter/index.ts
+++ b/toolkit/src/components/cut/filter-bar/filter/index.ts
@@ -3,28 +3,7 @@
  */
 
 import Component from '@glimmer/component';
-import { FilterConfig, ToggleArgs } from '..';
-
-interface FilterInterface {
-  Args: {
-    name: string;
-    config: FilterConfig;
-    localConfig: FilterConfig;
-    toggle: (toggle: ToggleArgs) => void;
-    softToggle: (toggle: ToggleArgs) => void;
-    applyFilter: (name: string) => void;
-    clearPendingFilter: () => void;
-    isChecked: (
-      localConfig: FilterConfig,
-      name: string,
-      value: unknown
-    ) => boolean;
-    isMultiSelect?: boolean;
-    batch?: boolean;
-    dropdown?: unknown;
-    listPosition?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
-  };
-}
+import { FilterSignature, ToggleArgs } from 'src/types';
 
 /**
  * `Cut::FilterBar::Filter` is a wrapper of the HDS::Dropdown component that exposes wrapped dropdown list items
@@ -43,7 +22,7 @@ interface FilterInterface {
  * @class Cut::FilterComponent
  *
  */
-export default class FilterComponent extends Component<FilterInterface> {
+export default class FilterComponent extends Component<FilterSignature> {
   get toggle(): (toggle: ToggleArgs) => void {
     return this.args.batch ? this.args.softToggle : this.args.toggle;
   }

--- a/toolkit/src/components/cut/filter-bar/filter/radio.ts
+++ b/toolkit/src/components/cut/filter-bar/filter/radio.ts
@@ -3,24 +3,9 @@
  */
 
 import Component from '@glimmer/component';
-import { FilterConfig, ToggleArgs } from '..';
+import { FilterBarCheckboxSignature } from 'src/types';
 
-interface FilterBarCheckbox {
-  Args: {
-    filterName: string;
-    name: string;
-    value: unknown;
-    localConfig: FilterConfig;
-    toggle: (toggle: ToggleArgs) => void;
-    isChecked: (
-      localConfig: FilterConfig,
-      name: string,
-      value: unknown
-    ) => boolean;
-  };
-}
-
-export default class CheckmarkComponent extends Component<FilterBarCheckbox> {
+export default class CheckmarkComponent extends Component<FilterBarCheckboxSignature> {
   get isChecked() {
     return this.args.isChecked(
       this.args.localConfig,

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -6,59 +6,15 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import structuredClone from '@ungap/structured-clone';
-
-export interface ComponentSignature {
-  Args: {
-    config: FilterConfig;
-    count?: number;
-    totalCount?: number;
-    onChange: (config: FilterConfig) => void;
-  };
-}
-
-export interface FilterConfig {
-  search?: Search;
-  filters?: Filters;
-  sort?: Sort;
-}
-
-interface Sort {
-  value?: string;
-}
-
-interface Search {
-  value?: string;
-}
-
-export interface Filter {
-  text: string;
-  value: unknown;
-  isRequired?: boolean;
-}
-
-export interface Filters {
-  [name: string]: Filter | Filter[] | undefined;
-}
-
-export interface AppliedFilter {
-  name: string;
-  value: Filter[];
-  isMultiSelect?: boolean;
-  isRequired?: boolean;
-}
-
-export type HTMLElementEvent<T extends HTMLElement> = Event & {
-  target: T;
-  currentTarget: T;
-};
-
-export interface ToggleArgs {
-  filterName: string;
-  value: unknown;
-  text: string;
-  isMultiSelect?: boolean;
-  isRequired?: boolean;
-}
+import {
+  AppliedFilter,
+  Filter,
+  FilterBarSignature,
+  FilterConfig,
+  Filters,
+  HTMLElementEvent,
+  ToggleArgs,
+} from 'src/types';
 
 /**
  * `Cut::FilterBar` provides the UI building blocks for building a FilterBar while also managing state for you.
@@ -89,7 +45,7 @@ export interface ToggleArgs {
  * in the `localConfig` but not yet in the `config`. Once you apply the pending changes, they will be applied to the
  * `config` and the `onChange` function will be called.
  */
-export default class FilterBarComponent extends Component<ComponentSignature> {
+export default class FilterBarComponent extends Component<FilterBarSignature> {
   @tracked pendingFilterChange: Filters = {};
 
   get localConfig(): FilterConfig {
@@ -244,7 +200,9 @@ export default class FilterBarComponent extends Component<ComponentSignature> {
     const config = structuredClone(this.args.config);
 
     // apply the filter from filterChanges
-    if (Object.hasOwn(this.pendingFilterChange || {}, name)) {
+    if (
+      Object.prototype.hasOwnProperty.call(this.pendingFilterChange || {}, name)
+    ) {
       config.filters = Object.assign({}, config.filters, {
         [name]: this.pendingFilterChange?.[name],
       });

--- a/toolkit/src/components/cut/filter-bar/sort/checkmark.ts
+++ b/toolkit/src/components/cut/filter-bar/sort/checkmark.ts
@@ -4,17 +4,9 @@
  */
 
 import Component from '@glimmer/component';
-import { FilterConfig } from '..';
+import { SortCheckmarkSignature } from 'src/types';
 
-interface SortCheckmarkInterface {
-  checkmark: unknown;
-  config: FilterConfig;
-  value: string;
-  name: string;
-  onSortChange: (value: string, text: string) => void;
-}
-
-export default class SortCheckmarkComponent extends Component<SortCheckmarkInterface> {
+export default class SortCheckmarkComponent extends Component<SortCheckmarkSignature> {
   get isSelected(): boolean {
     return this.args.config?.sort?.value === this.args.value;
   }

--- a/toolkit/src/components/cut/filter-bar/types.ts
+++ b/toolkit/src/components/cut/filter-bar/types.ts
@@ -1,0 +1,123 @@
+export interface FilterBarSignature {
+  Args: {
+    config: FilterConfig;
+    count?: number;
+    totalCount?: number;
+    onChange: (config: FilterConfig) => void;
+  };
+}
+
+export interface SortCheckmarkSignature {
+  Args: {
+    checkmark: unknown;
+    config: FilterConfig;
+    value: string;
+    name: string;
+    onSortChange: (value: string, text: string) => void;
+  };
+}
+
+export interface FilterSignature {
+  Args: {
+    name: string;
+    config: FilterConfig;
+    localConfig: FilterConfig;
+    toggle: (toggle: ToggleArgs) => void;
+    softToggle: (toggle: ToggleArgs) => void;
+    applyFilter: (name: string) => void;
+    clearPendingFilter: () => void;
+    isChecked: (
+      localConfig: FilterConfig,
+      name: string,
+      value: unknown
+    ) => boolean;
+    isMultiSelect?: boolean;
+    batch?: boolean;
+    dropdown?: unknown;
+    listPosition?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
+  };
+}
+
+export interface FilterBarCheckboxSignature {
+  Args: {
+    filterName: string;
+    name: string;
+    value: unknown;
+    localConfig: FilterConfig;
+    toggle: (toggle: ToggleArgs) => void;
+    isChecked: (
+      localConfig: FilterConfig,
+      name: string,
+      value: unknown
+    ) => boolean;
+  };
+}
+
+export interface FilterBarCheckboxSignature {
+  Args: {
+    filterName: string;
+    name: string;
+    value: unknown;
+    localConfig: FilterConfig;
+    toggle: (toggle: ToggleArgs) => void;
+    isChecked: (
+      localConfig: FilterConfig,
+      name: string,
+      value: unknown
+    ) => boolean;
+  };
+}
+
+export interface FilterBarCheckboxSignature {
+  Args: {
+    filterName: string;
+    name: string;
+    value: unknown;
+    localConfig: FilterConfig;
+    toggle: (toggle: ToggleArgs) => void;
+    isChecked: (
+      localConfig: FilterConfig,
+      name: string,
+      value: unknown
+    ) => boolean;
+  };
+}
+
+export interface FilterConfig {
+  search?: Search;
+  filters?: Filters;
+  sort?: Sort;
+}
+
+export interface Sort {
+  value?: string;
+}
+
+export interface Search {
+  value?: string;
+}
+
+export interface Filter {
+  text: string;
+  value: unknown;
+  isRequired?: boolean;
+}
+
+export interface Filters {
+  [name: string]: Filter | Filter[] | undefined;
+}
+
+export interface AppliedFilter {
+  name: string;
+  value: Filter[];
+  isMultiSelect?: boolean;
+  isRequired?: boolean;
+}
+
+export interface ToggleArgs {
+  filterName: string;
+  value: unknown;
+  text: string;
+  isMultiSelect?: boolean;
+  isRequired?: boolean;
+}

--- a/toolkit/src/components/cut/filter-bar/types.ts
+++ b/toolkit/src/components/cut/filter-bar/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export interface FilterBarSignature {
   Args: {
     config: FilterConfig;

--- a/toolkit/src/components/cut/list-item/index.ts
+++ b/toolkit/src/components/cut/list-item/index.ts
@@ -5,20 +5,9 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { ListItemSignature } from './types';
 
-export interface ComponentSignature {
-  Args: {
-    href?: string;
-    isHrefExternal?: boolean;
-    route?: string;
-    isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
-    onClick(): void;
-  };
-}
-
-export default class ListItemComponent extends Component<ComponentSignature> {
+export default class ListItemComponent extends Component<ListItemSignature> {
   get route() {
     const { onClick, route, href } = this.args;
 

--- a/toolkit/src/components/cut/list-item/service-instance/index.ts
+++ b/toolkit/src/components/cut/list-item/service-instance/index.ts
@@ -3,44 +3,9 @@
  */
 
 import Component from '@glimmer/component';
-import {
-  ExternalSource,
-  HealthCheck,
-} from '../../../../utils/service-list-item';
+import { ServiceInstanceListItemSignature } from '../types';
 
-export interface CutServiceInstance {
-  name?: string;
-  metadata: {
-    healthCheck: {
-      node?: HealthCheck;
-      service?: HealthCheck;
-    };
-    tags: string[];
-    servicePortAddress?: string;
-    serviceSocketPath?: string;
-    node?: string;
-    externalSource?: ExternalSource;
-    connectedWithProxy?: boolean;
-  };
-}
-
-interface ComponentSignature {
-  Args: {
-    // List item args;
-    href?: string;
-    isHrefExternal?: boolean;
-    route?: string;
-    isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
-    onClick(): void;
-
-    // Service args
-    service: CutServiceInstance;
-  };
-}
-
-export default class ServiceInstanceListItemComponent extends Component<ComponentSignature> {
+export default class ServiceInstanceListItemComponent extends Component<ServiceInstanceListItemSignature> {
   get isAllHealthy() {
     const { healthCheck } = this.args.service.metadata;
     const serviceHealthy = healthCheck.service

--- a/toolkit/src/components/cut/list-item/service/index.ts
+++ b/toolkit/src/components/cut/list-item/service/index.ts
@@ -4,50 +4,12 @@
 
 import Component from '@glimmer/component';
 import {
-  ExternalSource,
-  HealthCheck,
   NORMALIZED_GATEWAY_LABELS,
   SERVICE_GATEWAY_TYPE,
-  SERVICE_KIND,
 } from '../../../../utils/service-list-item';
+import { ServiceListItemSignature } from '../types';
 
-export interface CutService {
-  name: string | undefined;
-  metadata: {
-    healthCheck: {
-      instance?: HealthCheck;
-    };
-    kind?: SERVICE_KIND;
-    instanceCount?: number;
-    isImported?: boolean;
-    isPermissiveMTls?: boolean;
-    connectedWithGateway?: boolean;
-    connectedWithProxy?: boolean;
-    samenessGroup?: string;
-    externalSource?: ExternalSource;
-    tags: string[];
-    upstreamCount?: number;
-    linkedServiceCount?: number;
-  };
-}
-
-interface ComponentSignature {
-  Args: {
-    // List item args;
-    href?: string;
-    isHrefExternal?: boolean;
-    route?: string;
-    isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
-    onClick(): void;
-
-    // Service args
-    service: CutService;
-  };
-}
-
-export default class ServiceListItemComponent extends Component<ComponentSignature> {
+export default class ServiceListItemComponent extends Component<ServiceListItemSignature> {
   ServiceGatewayType = SERVICE_GATEWAY_TYPE;
   NormalizedGatewayLabels = NORMALIZED_GATEWAY_LABELS;
 

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export interface ListItemSignature {
   Args: {
     href?: string;

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -1,0 +1,102 @@
+export interface ListItemSignature {
+  Args: {
+    href?: string;
+    isHrefExternal?: boolean;
+    route?: string;
+    isRouteExternal?: boolean;
+    query?: object;
+    replace?: string;
+    onClick(): void;
+  };
+}
+
+export interface ServiceInstanceListItemSignature {
+  Args: {
+    // List item args;
+    href?: string;
+    isHrefExternal?: boolean;
+    route?: string;
+    isRouteExternal?: boolean;
+    query?: object;
+    replace?: string;
+    onClick(): void;
+
+    // Service args
+    service: CutServiceInstance;
+  };
+}
+
+export interface ServiceListItemSignature {
+  Args: {
+    // List item args;
+    href?: string;
+    isHrefExternal?: boolean;
+    route?: string;
+    isRouteExternal?: boolean;
+    query?: object;
+    replace?: string;
+    onClick(): void;
+
+    // Service args
+    service: CutService;
+  };
+}
+
+export interface CutServiceInstance {
+  name?: string;
+  metadata: {
+    healthCheck: {
+      node?: HealthCheck;
+      service?: HealthCheck;
+    };
+    tags: string[];
+    servicePortAddress?: string;
+    serviceSocketPath?: string;
+    node?: string;
+    externalSource?: ExternalSource;
+    connectedWithProxy?: boolean;
+  };
+}
+
+export interface CutService {
+  name: string | undefined;
+  metadata: {
+    healthCheck: {
+      instance?: HealthCheck;
+    };
+    kind?: SERVICE_KIND;
+    instanceCount?: number;
+    isImported?: boolean;
+    isPermissiveMTls?: boolean;
+    connectedWithGateway?: boolean;
+    connectedWithProxy?: boolean;
+    samenessGroup?: string;
+    externalSource?: ExternalSource;
+    tags: string[];
+    upstreamCount?: number;
+    linkedServiceCount?: number;
+  };
+}
+
+export interface HealthCheck {
+  success: number | undefined;
+  warning: number | undefined;
+  critical: number | undefined;
+}
+
+export type ExternalSource =
+  | 'kubernetes'
+  | 'terraform'
+  | 'nomad'
+  | 'consul'
+  | 'consul-api-gateway'
+  | 'vault'
+  | 'aws'
+  | 'aws-iam'
+  | 'lambda';
+
+export type SERVICE_KIND =
+  | 'api-gateway'
+  | 'mesh-gateway'
+  | 'ingress-gateway'
+  | 'terminating-gateway';

--- a/toolkit/src/components/cut/list/pagination.ts
+++ b/toolkit/src/components/cut/list/pagination.ts
@@ -6,20 +6,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import RouterService from '@ember/routing/router-service';
-
-interface PaginationArgs {
-  Args: {
-    nextCursor?: string;
-    prevCursor?: string;
-    pageSizes?: number[];
-    currentPageSize?: number;
-    queryFunction?: (page: string) => {
-      [key: string]: string | number | unknown;
-    };
-    onPageChange?: (page: string) => void;
-    onPageSizeChange?: (size: number) => void;
-  };
-}
+import { PaginationSignature } from 'src/types';
 
 /**
  * `Cut::List::Pagination` provides a wrapper around the `Hds::Pagination::Compact` and `Hds::Pagination::SizeSelector` components.
@@ -52,7 +39,7 @@ interface PaginationArgs {
  * when interacting with the page selectors and the size selectors. You can pass in a `onPageChange` action to have it call a function insteand.
  * The same goes for the size selector, but the argument is `onPageSizeChange`.
  */
-export default class PaginationComponent extends Component<PaginationArgs> {
+export default class PaginationComponent extends Component<PaginationSignature> {
   @service declare readonly router: RouterService;
 
   get queryFunction(): (page: string) => {

--- a/toolkit/src/components/cut/list/types.ts
+++ b/toolkit/src/components/cut/list/types.ts
@@ -1,0 +1,13 @@
+export interface PaginationSignature {
+  Args: {
+    nextCursor?: string;
+    prevCursor?: string;
+    pageSizes?: number[];
+    currentPageSize?: number;
+    queryFunction?: (page: string) => {
+      [key: string]: string | number | unknown;
+    };
+    onPageChange?: (page: string) => void;
+    onPageSizeChange?: (size: number) => void;
+  };
+}

--- a/toolkit/src/components/cut/list/types.ts
+++ b/toolkit/src/components/cut/list/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export interface PaginationSignature {
   Args: {
     nextCursor?: string;

--- a/toolkit/src/components/cut/metadata/external-source/index.ts
+++ b/toolkit/src/components/cut/metadata/external-source/index.ts
@@ -6,16 +6,10 @@ import Component from '@glimmer/component';
 import {
   EXTERNAL_SOURCE_ICON_MAPPING,
   EXTERNAL_SOURCE_LABELS,
-  ExternalSource,
 } from '../../../../utils/service-list-item';
+import { MetadataExternalSourceSignature } from 'src/types';
 
-interface ComponentSignature {
-  Args: {
-    externalSource: ExternalSource;
-  };
-}
-
-export default class MetadataExternalSourceComponent extends Component<ComponentSignature> {
+export default class MetadataExternalSourceComponent extends Component<MetadataExternalSourceSignature> {
   get externalSourceIcon() {
     const { externalSource } = this.args;
 

--- a/toolkit/src/components/cut/metadata/health-check-badge-set/index.ts
+++ b/toolkit/src/components/cut/metadata/health-check-badge-set/index.ts
@@ -3,17 +3,9 @@
  */
 
 import Component from '@glimmer/component';
+import { MetadataHealthCheckBadgeSetSignature } from 'src/types';
 
-interface ComponentSignature {
-  Args: {
-    type: string;
-    successCount?: number;
-    criticalCount?: number;
-    warningCount?: number;
-  };
-}
-
-export default class MetadataHealthCheckBadgeSetComponent extends Component<ComponentSignature> {
+export default class MetadataHealthCheckBadgeSetComponent extends Component<MetadataHealthCheckBadgeSetSignature> {
   get total() {
     return (
       (this.args.successCount || 0) +

--- a/toolkit/src/components/cut/metadata/types.ts
+++ b/toolkit/src/components/cut/metadata/types.ts
@@ -1,0 +1,16 @@
+import { ExternalSource } from 'src/types';
+
+export interface MetadataHealthCheckBadgeSetSignature {
+  Args: {
+    type: string;
+    successCount?: number;
+    criticalCount?: number;
+    warningCount?: number;
+  };
+}
+
+export interface MetadataExternalSourceSignature {
+  Args: {
+    externalSource: ExternalSource;
+  };
+}

--- a/toolkit/src/components/cut/metadata/types.ts
+++ b/toolkit/src/components/cut/metadata/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 import { ExternalSource } from 'src/types';
 
 export interface MetadataHealthCheckBadgeSetSignature {

--- a/toolkit/src/components/cut/text-with-icon/index.ts
+++ b/toolkit/src/components/cut/text-with-icon/index.ts
@@ -3,16 +3,7 @@
  */
 
 import Component from '@glimmer/component';
-
-export interface DivSignature {
-  Element: HTMLDivElement;
-  Args: {
-    icon: string;
-    text: string;
-    connection?: string | undefined;
-    iconColor?: string | undefined;
-  };
-}
+import { TextWithIconSignature } from 'src/types';
 
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes
-export default class TextWithIconComponent extends Component<DivSignature> {}
+export default class TextWithIconComponent extends Component<TextWithIconSignature> {}

--- a/toolkit/src/components/cut/text-with-icon/types.ts
+++ b/toolkit/src/components/cut/text-with-icon/types.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export interface TextWithIconSignature {
   Element: HTMLDivElement;
   Args: {

--- a/toolkit/src/components/cut/text-with-icon/types.ts
+++ b/toolkit/src/components/cut/text-with-icon/types.ts
@@ -1,0 +1,9 @@
+export interface TextWithIconSignature {
+  Element: HTMLDivElement;
+  Args: {
+    icon: string;
+    text: string;
+    connection?: string | undefined;
+    iconColor?: string | undefined;
+  };
+}

--- a/toolkit/src/index.ts
+++ b/toolkit/src/index.ts
@@ -1,4 +1,6 @@
 /**
  * Copyright (c) HashiCorp, Inc.
  */
-export {};
+
+export * from './utils';
+export type * from './types';

--- a/toolkit/src/types/index.ts
+++ b/toolkit/src/types/index.ts
@@ -1,0 +1,11 @@
+export type * from '../components/cut/list-item/types';
+export type * from '../components/cut/filter-bar/types';
+export type * from '../components/cut/list/types';
+export type * from '../components/cut/copy-block/types';
+export type * from '../components/cut/metadata/types';
+export type * from '../components/cut/text-with-icon/types';
+
+export type HTMLElementEvent<T extends HTMLElement> = Event & {
+  target: T;
+  currentTarget: T;
+};

--- a/toolkit/src/types/index.ts
+++ b/toolkit/src/types/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export type * from '../components/cut/list-item/types';
 export type * from '../components/cut/filter-bar/types';
 export type * from '../components/cut/list/types';

--- a/toolkit/src/utils/index.ts
+++ b/toolkit/src/utils/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
 export * from './service-list-item';

--- a/toolkit/src/utils/index.ts
+++ b/toolkit/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './service-list-item';

--- a/toolkit/src/utils/service-list-item.ts
+++ b/toolkit/src/utils/service-list-item.ts
@@ -2,17 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  */
 
-export type ExternalSource =
-  | 'kubernetes'
-  | 'terraform'
-  | 'nomad'
-  | 'consul'
-  | 'consul-api-gateway'
-  | 'vault'
-  | 'aws'
-  | 'aws-iam'
-  | 'lambda';
-
 export enum EXTERNAL_SOURCE_ICON_MAPPING {
   kubernetes = 'kubernetes-color',
   terraform = 'terraform-color',
@@ -37,12 +26,6 @@ export enum EXTERNAL_SOURCE_LABELS {
   lambda = 'AWS Lambda',
 }
 
-export interface HealthCheck {
-  success: number | undefined;
-  warning: number | undefined;
-  critical: number | undefined;
-}
-
 export const CUT_SERVICE_LIST_ITEM_TYPE = {
   Service: 'service',
   ServiceInstance: 'service-instance',
@@ -61,9 +44,3 @@ export const SERVICE_GATEWAY_TYPE = {
   IngressGateway: 'ingress-gateway',
   TerminatingGateway: 'terminating-gateway',
 };
-
-export type SERVICE_KIND =
-  | 'api-gateway'
-  | 'mesh-gateway'
-  | 'ingress-gateway'
-  | 'terminating-gateway';


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
I was working on building the services list ui cloud-ui and I found that I had to import constants and types from the actual dist folder and the path to where the export was happening. I didn't like how that made me feel so I did some work to change that. Now if you want any types to be exported from the root package you can export them from the `types/index.ts` file. Similarly you can also export any utility constants/functions from `utils/index.ts` to also be able to import them straight from `@hashicorp/consul-ui-toolkit`.

I made this a major change as it breaks where types were located. It really doesn't matter yet as the previous version hadn't been used except in my wip PR but there is not harm in versioning.

### :camera_flash: Screenshots

**Before:**
<img width="981" alt="Screenshot 2023-08-24 at 3 03 42 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/2134f40e-498c-423f-b786-e9bca1728d3f">

**After:**
<img width="981" alt="Screenshot 2023-08-24 at 3 05 46 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/17469021-6a39-435e-b1ce-1b935a1beb20">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-6167](https://hashicorp.atlassian.net/browse/CC-6167)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->
I tested this out with [yalc](https://github.com/wclr/yalc). You have to install it globally.
- I ran `yarn publish:local:toolkit` in this repo
- Then in the cloud-ui I ran `yalc add @hashicorp/consul-ui-toolkit` and imported some code.

You can try this out in any app that is using TS. Initially I wanted to confirm it was just a toolkit issue so I tested it out with an ember addon that was using ts.

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [x] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-6167]: https://hashicorp.atlassian.net/browse/CC-6167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ