### PR TITLE
CC-5556: Update list pagination routing behaviour

### DIFF
--- a/.changeset/nasty-shoes-repair.md
+++ b/.changeset/nasty-shoes-repair.md
@@ -1,0 +1,6 @@
+---
+'@hashicorp/consul-ui-toolkit': major
+---
+
+Update pagination pagesize handler to always specify the current route when transitioning
+Update pagination routing to set separate query params for next or prev page

--- a/toolkit/src/components/cut/list/pagination.ts
+++ b/toolkit/src/components/cut/list/pagination.ts
@@ -52,7 +52,8 @@ export default class PaginationComponent extends Component<PaginationSignature> 
 
       return (page) =>
         Object.assign({}, queryParams, {
-          page: page === 'prev' ? this.args.prevCursor : this.args.nextCursor,
+          previousPage: page === 'prev' ? this.args.prevCursor : undefined,
+          nextPage: page === 'next' ? this.args.nextCursor : undefined,
         });
     }
   }
@@ -67,7 +68,7 @@ export default class PaginationComponent extends Component<PaginationSignature> 
         pageSize: size,
       });
 
-      this.router.transitionTo({
+      this.router.transitionTo(this.router.currentRouteName, {
         queryParams: newParams,
       });
     }


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Updates the paginaton page size default handler to always specify the route name when transitioning
Updates the pagination routing query function to set separate query parameters for next or previous page.

Grouping this breaking change with the other current major change that is pending release.

### :camera_flash: Screenshots


https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/e574bad9-a362-4e0c-a267-5a2828c7e7cc



### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-5556](https://hashicorp.atlassian.net/browse/CC-5556)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-5556]: https://hashicorp.atlassian.net/browse/CC-5556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ