### PR TITLE
CC-5556: list-item - pass models/model through to HDS::Interactive

### DIFF
--- a/.changeset/healthy-lamps-hammer.md
+++ b/.changeset/healthy-lamps-hammer.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Pass through models, model on list-item to the HDS::Interactive component

--- a/toolkit/src/components/cut/list-item/index.hbs
+++ b/toolkit/src/components/cut/list-item/index.hbs
@@ -15,6 +15,8 @@
       @isHrefExternal={{@isHrefExternal}}
       @query={{@query}}
       @replace={{@replace}}
+      @model={{@model}}
+      @models={{@models}}
       {{on 'click' this.onClickAction}}
       ...attributes
     >

--- a/toolkit/src/components/cut/list-item/service-instance/index.hbs
+++ b/toolkit/src/components/cut/list-item/service-instance/index.hbs
@@ -6,6 +6,8 @@
   @href={{@href}}
   @isRouteExternal={{@isRouteExternal}}
   @route={{@route}}
+  @model={{@model}}
+  @models={{@models}}
   @isHrefExternal={{@isHrefExternal}}
   @query={{@query}}
   @replace={{@replace}}

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -6,6 +6,8 @@
   @href={{@href}}
   @isRouteExternal={{@isRouteExternal}}
   @route={{@route}}
+  @model={{@model}}
+  @models={{@models}}
   @isHrefExternal={{@isHrefExternal}}
   @query={{@query}}
   @replace={{@replace}}

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -10,6 +10,8 @@ export interface ListItemSignature {
     isRouteExternal?: boolean;
     query?: object;
     replace?: string;
+    model?: string | unknown;
+    models?: string[] | unknown[];
     onClick(): void;
   };
 }
@@ -23,6 +25,8 @@ export interface ServiceInstanceListItemSignature {
     isRouteExternal?: boolean;
     query?: object;
     replace?: string;
+    model?: string | unknown;
+    models?: string[] | unknown[];
     onClick(): void;
 
     // Service args
@@ -39,6 +43,8 @@ export interface ServiceListItemSignature {
     isRouteExternal?: boolean;
     query?: object;
     replace?: string;
+    model?: string | unknown;
+    models?: string[] | unknown[];
     onClick(): void;
 
     // Service args


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Pass through the model and models to the underlying `Hds::Interactive` component in `Cut::ListItem`, `Cut::ListItem::Service` and `Cut::ListItem::ServiceInstance`

### :camera_flash: Screenshots

https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/bb0f0c30-3b31-4d86-9c65-912b4e50d649



### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
