### PR TITLE
CC-5556: update filter bar results text

### DIFF
--- a/.changeset/ten-pianos-drum.md
+++ b/.changeset/ten-pianos-drum.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': minor
+---
+
+Add @name argument to Cut::FilterBar and update default result text

--- a/documentation/app/templates/components/filter-bar.hbs
+++ b/documentation/app/templates/components/filter-bar.hbs
@@ -16,6 +16,7 @@
 
 <Cut::FilterBar
   @config={{this.filters}}
+  @name="service"
   @count={{this.count}}
   @onChange={{this.handleFilterChange}}
   as |FB|
@@ -221,7 +222,6 @@
 
 <Cut::FilterBar
   @config={{this.filters}}
-  @count={{this.count}}
   @onChange={{this.handleFilterChange}}
   as |FB|
 >

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -15,7 +15,13 @@ import {
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-async function setupTest(config) {
+async function setupTest({ config, name, count, totalCount } = {}) {
+  this.set('name', name);
+
+  this.set('count', count);
+
+  this.set('totalCount', totalCount);
+
   this.set(
     'config',
     config || {
@@ -44,7 +50,7 @@ async function setupTest(config) {
   this.onChange = onChange;
 
   await render(hbs`
-    <Cut::FilterBar @config={{this.config}} @onChange={{this.onChange}} as |FB|>
+    <Cut::FilterBar @config={{this.config}} @name={{this.name}} @count={{this.count}} @totalCount={{this.totalCount}} @onChange={{this.onChange}} as |FB|>
       <FB.Search placeholder="Search for services" data-test-search />
       <FB.FilterGroup as |Filters|>
         <Filters.Filter
@@ -159,19 +165,21 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
 
   test("clear filters doesn't show when there are only required filters", async function (assert) {
     await setupTest.call(this, {
-      search: {
-        value: '',
-      },
-      filters: {
-        juice: {
-          text: 'Orange',
-          value: 'oj',
-          isRequired: true,
+      config: {
+        search: {
+          value: '',
         },
-      },
-      sort: {
-        text: 'critical to healthy',
-        value: 'health',
+        filters: {
+          juice: {
+            text: 'Orange',
+            value: 'oj',
+            isRequired: true,
+          },
+        },
+        sort: {
+          text: 'critical to healthy',
+          value: 'health',
+        },
       },
     });
 
@@ -317,6 +325,44 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
       },
       'Sort is updated to be instance count'
     );
+  });
+
+  test('shows a default results text if no count is passed in', async function (assert) {
+    await setupTest.call(this);
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing all results');
+  });
+
+  test('shows a default results text with the name if the name is passed in with no count', async function (assert) {
+    await setupTest.call(this, { name: 'nacho' });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing all nachos');
+  });
+
+  test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {
+    await setupTest.call(this, { count: 3 });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing 3 results');
+  });
+
+  test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {
+    await setupTest.call(this, { count: 3 });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing 3 results');
+  });
+
+  test('shows a result count with a name if you pass in a count and a name', async function (assert) {
+    await setupTest.call(this, { count: 1, name: 'song' });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing 1 song');
+  });
+
+  test('shows a result count with a total if you pass in a total and a count', async function (assert) {
+    await setupTest.call(this, { count: 5, totalCount: 10, name: 'song' });
+
+    assert
+      .dom('[data-test-filter-bar-results]')
+      .hasText('Showing 5 songs of 10');
   });
 
   test('search updates the search values', async function (assert) {

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -345,12 +345,6 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
     assert.dom('[data-test-filter-bar-results]').hasText('Showing 3 results');
   });
 
-  test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {
-    await setupTest.call(this, { count: 3 });
-
-    assert.dom('[data-test-filter-bar-results]').hasText('Showing 3 results');
-  });
-
   test('shows a result count with a name if you pass in a count and a name', async function (assert) {
     await setupTest.call(this, { count: 1, name: 'song' });
 

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -74,13 +74,18 @@
   </div>
 
   <div class='cut-filter-bar-results'>
-    {{#let (if @count @count 0) as |count|}}
-      <p class='cut-filter-bar-results-count'>Showing
-        {{pluralize count 'result'}}{{if
+    <p class='cut-filter-bar-results-count' data-test-filter-bar-results>
+      {{#if this.hasCount}}
+        Showing
+        {{pluralize @count (if @name @name 'result')}}{{if
           @totalCount
           (concat ' of ' @totalCount)
-        }}</p>
-    {{/let}}
+        }}
+      {{else}}
+        Showing all
+        {{if @name (pluralize @name) 'results'}}
+      {{/if}}
+    </p>
 
     {{#each this.appliedFilters as |filter|}}
       <p class='cut-filter-bar-applied-filter-label'>{{titlecase

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -105,6 +105,10 @@ export default class FilterBarComponent extends Component<FilterBarSignature> {
     );
   }
 
+  get hasCount(): boolean {
+    return typeof this.args.count === 'number';
+  }
+
   isChecked(localConfig: FilterConfig, filter: string, value: unknown) {
     if (Array.isArray(localConfig?.filters?.[filter])) {
       return !!(localConfig?.filters?.[filter] as Filter[]).find(

--- a/toolkit/src/components/cut/filter-bar/types.ts
+++ b/toolkit/src/components/cut/filter-bar/types.ts
@@ -5,6 +5,7 @@
 export interface FilterBarSignature {
   Args: {
     config: FilterConfig;
+    name?: string;
     count?: number;
     totalCount?: number;
     onChange: (config: FilterConfig) => void;


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Adds the `@name` argument to `Cut::FilterBar` and updates the default text to show generic result text that doesn't reference the number of returned items.

### :camera_flash: Screenshots

<img width="1211" alt="Screenshot 2023-08-28 at 3 49 14 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/8297a8e4-73a5-4dec-8d42-450c2f59c8b6">
<img width="1261" alt="Screenshot 2023-08-28 at 3 48 55 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/d9d839bb-669d-4185-ae4d-b7a951346aa0">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
