### PR TITLE
Add cut-link class for link overrides

### DIFF
--- a/.changeset/popular-cars-pump.md
+++ b/.changeset/popular-cars-pump.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Add cut-link class for link overrides

--- a/toolkit/src/components/cut/list-item/index.hbs
+++ b/toolkit/src/components/cut/list-item/index.hbs
@@ -7,8 +7,10 @@
   ...attributes
 >
   {{#if (or @route @href @onClick)}}
+    {{! cut-link is a class that is used in the structure override classes to avoid applying 
+      extra styles to the link from structure. (https://github.com/hashicorp/structure/blob/d00c8bf39c22b5490a4c6fa8bae951b934432dfb/packages/pds-ember/app/styles/pds/_overrides.scss) }}
     <Hds::Interactive
-      class='cut-list-item__content-container active'
+      class='cut-link cut-list-item__content-container active'
       @href={{this.href}}
       @isRouteExternal={{@isRouteExternal}}
       @route={{this.route}}


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Adds `cut-link` class to the `Cut::ListItem` interactive element so that we can include it in the [link overrides in structure](https://github.com/hashicorp/structure/pull/146).

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
