### PR TITLE
CC-6116: filter bar results text

### DIFF
--- a/.changeset/selfish-mice-shout.md
+++ b/.changeset/selfish-mice-shout.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update default `Cut::FilterBar` results text when no count is passed in.

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -327,32 +327,43 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
     );
   });
 
-  test('shows a default results text if no count is passed in', async function (assert) {
-    await setupTest.call(this);
+  test('shows a default results text if no count is passed in and no filters are selected', async function (assert) {
+    await setupTest.call(this, { config: {} });
 
     assert.dom('[data-test-filter-bar-results]').hasText('Showing all results');
   });
 
   test('shows a default results text with the name if the name is passed in with no count', async function (assert) {
-    await setupTest.call(this, { name: 'nacho' });
+    await setupTest.call(this, { config: {}, name: 'nacho' });
 
     assert.dom('[data-test-filter-bar-results]').hasText('Showing all nachos');
   });
 
+  test('shows a default filters applied text when there are filters applied and no count is passed in', async function (assert) {
+    await setupTest.call(this, { name: 'nacho' });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Filters applied:');
+  });
+
   test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {
-    await setupTest.call(this, { count: 3 });
+    await setupTest.call(this, { config: {}, count: 3 });
 
     assert.dom('[data-test-filter-bar-results]').hasText('Showing 3 results');
   });
 
   test('shows a result count with a name if you pass in a count and a name', async function (assert) {
-    await setupTest.call(this, { count: 1, name: 'song' });
+    await setupTest.call(this, { config: {}, count: 1, name: 'song' });
 
     assert.dom('[data-test-filter-bar-results]').hasText('Showing 1 song');
   });
 
   test('shows a result count with a total if you pass in a total and a count', async function (assert) {
-    await setupTest.call(this, { count: 5, totalCount: 10, name: 'song' });
+    await setupTest.call(this, {
+      config: {},
+      count: 5,
+      totalCount: 10,
+      name: 'song',
+    });
 
     assert
       .dom('[data-test-filter-bar-results]')

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -81,6 +81,8 @@
           @totalCount
           (concat ' of ' @totalCount)
         }}
+      {{else if this.isFiltering}}
+        Filters applied:
       {{else}}
         Showing all
         {{if @name (pluralize @name) 'results'}}

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -109,6 +109,11 @@ export default class FilterBarComponent extends Component<FilterBarSignature> {
     return typeof this.args.count === 'number';
   }
 
+  get isFiltering(): boolean {
+    console.log(this.args.config);
+    return Object.keys(this.args.config?.filters || {}).length > 0;
+  }
+
   isChecked(localConfig: FilterConfig, filter: string, value: unknown) {
     if (Array.isArray(localConfig?.filters?.[filter])) {
       return !!(localConfig?.filters?.[filter] as Filter[]).find(

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -110,7 +110,6 @@ export default class FilterBarComponent extends Component<FilterBarSignature> {
   }
 
   get isFiltering(): boolean {
-    console.log(this.args.config);
     return Object.keys(this.args.config?.filters || {}).length > 0;
   }
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Updates the FilterBar results text to be "Filters applied:" when no count is passed in and you have used at least one filter

### :camera_flash: Screenshots
<img width="1211" alt="Screenshot 2023-08-29 at 2 24 59 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/9308746c-dc34-40f3-a069-490103ed8293">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-6116](https://hashicorp.atlassian.net/browse/CC-6116)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-6116]: https://hashicorp.atlassian.net/browse/CC-6116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ