### PR TITLE
CC-6223: Update how statuses are displayed on Cut::ListItem::Service

### DIFF
--- a/.changeset/beige-clouds-work.md
+++ b/.changeset/beige-clouds-work.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': minor
+---
+
+Service list item now displays an overall service health status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,14 @@
 ### Publishing toolkit locally
 
 - from root `publish:local:toolkit`
-- or `cd toolkit` and `yarn publish:local` – Publishing `@hashocorp/consul-ui-toolkit` to local `.yalc` store
-- from the dependent project `yalc link @hashocorp/consul-ui-toolkit`
+- or `cd toolkit` and `yarn publish:local` – Publishing `@hashicorp/consul-ui-toolkit` to local `.yalc` store
+- from the dependent project `yalc link @hashicorp/consul-ui-toolkit`
   - in HCP you will need to run `yalc link @hashicorp/consul-ui-toolkit` in both the `hcp` folder and the `engines/consul` folder
 
 ### Remove toolkit package from local .yalc store
 
 - from root `cleanup:local:toolkit`
-- or `cd toolkit` and `yarn cleanup:local` – Removing `@hashocorp/consul-ui-toolkit` from local `.yalc` store
+- or `cd toolkit` and `yarn cleanup:local` – Removing `@hashicorp/consul-ui-toolkit` from local `.yalc` store
 - Run `yalc remove @hashicorp/consul-ui-toolkit` or `yalc remove --all` to remove the symlinks in any dependent project that currently has a `yalc link` set up.
 
 ## Running the test application

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -51,34 +51,18 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     assert.true(cutService.renders, 'renders component');
     assert.deepEqual(cutService.title, 'Service 1', 'service name is set');
     assert.false(
-      cutService.metadata.healthCheck.allHealthy,
-      'no all healthy badge if some warning or critical present'
-    );
-    assert.false(
-      cutService.metadata.healthCheck.success.renders,
-      'no success healthcheck if some warning or critical present'
+      cutService.metadata.healthCheck.healthy.renders,
+      'healthy status badge does not render if there are warning or critical healthchecks'
     );
     assert.true(
       cutService.metadata.healthCheck.critical.renders,
-      'renders critical'
+      'renders critical status badge'
     );
-    assert.true(
-      cutService.metadata.healthCheck.critical.text.includes(
-        `${critical}/${healthCheckTotal}`
-      ),
-      'renders correct number of critical checks'
+    assert.false(
+      cutService.metadata.healthCheck.warning.renders,
+      'warning status badge does not render if there are critical healthchecks'
     );
 
-    assert.true(
-      cutService.metadata.healthCheck.warning.renders,
-      'renders warning'
-    );
-    assert.true(
-      cutService.metadata.healthCheck.warning.text.includes(
-        `${warning}/${healthCheckTotal}`
-      ),
-      'renders correct number of warning checks'
-    );
     assert.true(cutService.metadata.kind.renders, 'renders kind name');
     assert.true(
       cutService.metadata.kind.text
@@ -161,10 +145,10 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     assert.true(cutService.renders, 'renders');
     assert.deepEqual(cutService.title, 'Service 1', 'service name is set');
     assert.true(
-      cutService.metadata.healthCheck.allHealthy,
-      'present All Healthy badge cause no critical and warning checks'
+      cutService.metadata.healthCheck.healthy.renders,
+      'renders healthy status badge'
     );
-    assert.false(cutService.metadata.healthCheck.success.renders, 'success');
+    debugger;
     assert.false(cutService.metadata.healthCheck.critical.renders, 'critical');
     assert.false(cutService.metadata.healthCheck.warning.renders, 'warning');
     assert.false(cutService.metadata.kind.renders, 'kind');

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -41,8 +41,6 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
       },
     };
     this.set('service', service);
-    let { success, critical, warning } = service.metadata.healthCheck.instance;
-    let healthCheckTotal = critical + success + warning;
 
     await render(
       hbs`
@@ -148,7 +146,7 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
       cutService.metadata.healthCheck.healthy.renders,
       'renders healthy status badge'
     );
-    debugger;
+
     assert.false(cutService.metadata.healthCheck.critical.renders, 'critical');
     assert.false(cutService.metadata.healthCheck.warning.renders, 'warning');
     assert.false(cutService.metadata.kind.renders, 'kind');

--- a/documentation/tests/pages/service-list-item.js
+++ b/documentation/tests/pages/service-list-item.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { create, isPresent, isVisible, text } from 'ember-cli-page-object';
+import { create, isPresent, text } from 'ember-cli-page-object';
 
 const listItemSelector = '[data-test-service-list-item]';
 export default create({
@@ -15,19 +15,25 @@ export default create({
         renders: isPresent(
           `${listItemSelector} [data-test-service-health-check-healthy]`
         ),
-        text: text(`${listItemSelector} [data-test-service-health-check-healthy]`),
+        text: text(
+          `${listItemSelector} [data-test-service-health-check-healthy]`
+        ),
       },
       critical: {
         renders: isPresent(
           `${listItemSelector} [data-test-service-health-check-critical]`
         ),
-        text: text(`${listItemSelector} [data-test-service-health-check-critical]`),
+        text: text(
+          `${listItemSelector} [data-test-service-health-check-critical]`
+        ),
       },
       warning: {
         renders: isPresent(
           `${listItemSelector} [data-test-service-health-check-warning]`
         ),
-        text: text(`${listItemSelector} [data-test-service-health-check-warning]`),
+        text: text(
+          `${listItemSelector} [data-test-service-health-check-warning]`
+        ),
       },
     },
     kind: {

--- a/documentation/tests/pages/service-list-item.js
+++ b/documentation/tests/pages/service-list-item.js
@@ -11,26 +11,23 @@ export default create({
   title: text(`${listItemSelector} [data-test-service-name]`),
   metadata: {
     healthCheck: {
-      allHealthy: isVisible(
-        `${listItemSelector} [data-test-health-check-all-healthy]`
-      ),
-      success: {
+      healthy: {
         renders: isPresent(
-          `${listItemSelector} [data-test-health-check-success]`
+          `${listItemSelector} [data-test-service-health-check-healthy]`
         ),
-        text: text(`${listItemSelector} [data-test-health-check-success]`),
+        text: text(`${listItemSelector} [data-test-service-health-check-healthy]`),
       },
       critical: {
         renders: isPresent(
-          `${listItemSelector} [data-test-health-check-critical]`
+          `${listItemSelector} [data-test-service-health-check-critical]`
         ),
-        text: text(`${listItemSelector} [data-test-health-check-critical]`),
+        text: text(`${listItemSelector} [data-test-service-health-check-critical]`),
       },
       warning: {
         renders: isPresent(
-          `${listItemSelector} [data-test-health-check-warning]`
+          `${listItemSelector} [data-test-service-health-check-warning]`
         ),
-        text: text(`${listItemSelector} [data-test-health-check-warning]`),
+        text: text(`${listItemSelector} [data-test-service-health-check-warning]`),
       },
     },
     kind: {

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -122,6 +122,7 @@
       "./components/cut/metadata/external-source/index.js": "./dist/_app_/components/cut/metadata/external-source/index.js",
       "./components/cut/metadata/health-check-badge-set/index.js": "./dist/_app_/components/cut/metadata/health-check-badge-set/index.js",
       "./components/cut/metadata/in-service-mesh/index.js": "./dist/_app_/components/cut/metadata/in-service-mesh/index.js",
+      "./components/cut/metadata/service-health-badge/index.js": "./dist/_app_/components/cut/metadata/service-health-badge/index.js",
       "./components/cut/metadata/tags/index.js": "./dist/_app_/components/cut/metadata/tags/index.js",
       "./components/cut/metadata/types.js": "./dist/_app_/components/cut/metadata/types.js",
       "./components/cut/text-with-icon/index.js": "./dist/_app_/components/cut/text-with-icon/index.js",

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -20,24 +20,16 @@
       <T.Section as |SC|>
         <SC.Title data-test-service-name>{{@service.name}}</SC.Title>
         <SC.Metadata>
-          {{#if this.isAllHealthy}}
-            <Hds::Badge
-              @color='success'
-              @icon='check'
-              @text='Healthy'
-              @size='small'
-              data-test-health-check-all-healthy
-            />
-          {{else}}
-            <!--Instance health check-->
-            {{#if @service.metadata.healthCheck.instance}}
+            <!--Overall service health check-->
+          {{#if @service.metadata.healthCheck.instance}}
+            <Hds::TooltipButton @text={{this.tooltipText}} @placement="bottom">
               <Cut::Metadata::HealthCheckBadgeSet
                 @successCount={{@service.metadata.healthCheck.instance.success}}
                 @warningCount={{@service.metadata.healthCheck.instance.warning}}
                 @criticalCount={{@service.metadata.healthCheck.instance.critical}}
-                @type='instance'
+                @type='service-parent'
               />
-            {{/if}}
+            </Hds::TooltipButton>
           {{/if}}
           {{#if @service.metadata.kind}}
             <Cut::TextWithIcon

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -20,17 +20,11 @@
       <T.Section as |SC|>
         <SC.Title data-test-service-name>{{@service.name}}</SC.Title>
         <SC.Metadata>
-            <!--Overall service health check-->
-          {{#if @service.metadata.healthCheck.instance}}
-            <Hds::TooltipButton @text={{this.tooltipText}} @placement="bottom">
-              <Cut::Metadata::HealthCheckBadgeSet
-                @successCount={{@service.metadata.healthCheck.instance.success}}
-                @warningCount={{@service.metadata.healthCheck.instance.warning}}
-                @criticalCount={{@service.metadata.healthCheck.instance.critical}}
-                @type='service-parent'
-              />
-            </Hds::TooltipButton>
-          {{/if}}
+          <Cut::Metadata::ServiceHealthBadge
+            @successCount={{@service.metadata.healthCheck.instance.success}}
+            @warningCount={{@service.metadata.healthCheck.instance.warning}}
+            @criticalCount={{@service.metadata.healthCheck.instance.critical}}
+          />
           {{#if @service.metadata.kind}}
             <Cut::TextWithIcon
               @icon='gateway'

--- a/toolkit/src/components/cut/list-item/service/index.ts
+++ b/toolkit/src/components/cut/list-item/service/index.ts
@@ -13,12 +13,15 @@ export default class ServiceListItemComponent extends Component<ServiceListItemS
   ServiceGatewayType = SERVICE_GATEWAY_TYPE;
   NormalizedGatewayLabels = NORMALIZED_GATEWAY_LABELS;
 
-  get isAllHealthy() {
+  get tooltipText() {
     const { healthCheck } = this.args.service.metadata;
-
-    return healthCheck.instance
-      ? !healthCheck.instance.critical && !healthCheck.instance.warning
-      : true;
+    
+    if (healthCheck!.instance!.critical! > 0) {
+      return '1 or more instances is critical';
+    } else if (healthCheck!.instance!.warning! > 0) {
+      return '1 or more instances has a warning';
+    }
+    return 'All instances are healthy'
   }
 
   get isIngressGateway() {

--- a/toolkit/src/components/cut/list-item/service/index.ts
+++ b/toolkit/src/components/cut/list-item/service/index.ts
@@ -13,17 +13,6 @@ export default class ServiceListItemComponent extends Component<ServiceListItemS
   ServiceGatewayType = SERVICE_GATEWAY_TYPE;
   NormalizedGatewayLabels = NORMALIZED_GATEWAY_LABELS;
 
-  get tooltipText() {
-    const { healthCheck } = this.args.service.metadata;
-
-    if (healthCheck!.instance!.critical! > 0) {
-      return '1 or more instances is critical';
-    } else if (healthCheck!.instance!.warning! > 0) {
-      return '1 or more instances has a warning';
-    }
-    return 'All instances are healthy';
-  }
-
   get isIngressGateway() {
     return (
       this.args.service.metadata.kind === this.ServiceGatewayType.IngressGateway

--- a/toolkit/src/components/cut/list-item/service/index.ts
+++ b/toolkit/src/components/cut/list-item/service/index.ts
@@ -15,13 +15,13 @@ export default class ServiceListItemComponent extends Component<ServiceListItemS
 
   get tooltipText() {
     const { healthCheck } = this.args.service.metadata;
-    
+
     if (healthCheck!.instance!.critical! > 0) {
       return '1 or more instances is critical';
     } else if (healthCheck!.instance!.warning! > 0) {
       return '1 or more instances has a warning';
     }
-    return 'All instances are healthy'
+    return 'All instances are healthy';
   }
 
   get isIngressGateway() {

--- a/toolkit/src/components/cut/metadata/health-check-badge-set/index.hbs
+++ b/toolkit/src/components/cut/metadata/health-check-badge-set/index.hbs
@@ -7,10 +7,7 @@
     <Hds::Badge
       @color='critical'
       @icon='x'
-      @text={{if (eq @type 'service-parent') 
-        'Critical'
-        (concat @criticalCount '/' this.total ' ' @type ' checks')
-      }}
+      @text={{concat @criticalCount '/' this.total ' ' @type ' checks'}}
       @size="small"
       data-test-health-check-critical={{@type}}
     />
@@ -20,10 +17,7 @@
     <Hds::Badge
       @color='warning'
       @icon='alert-triangle'
-      @text={{if (eq @type 'service-parent') 
-        'Warning'
-        (concat @warningCount '/' this.total ' ' @type ' checks')
-      }}
+      @text={{concat @warningCount '/' this.total ' ' @type ' checks'}}
       @size="small"
       data-test-health-check-warning={{@type}}
     />
@@ -33,10 +27,7 @@
     <Hds::Badge
       @color='success'
       @icon='check'
-      @text={{if (eq @type 'service-parent') 
-        'Healthy'
-        (concat @successCount '/' this.total ' ' @type ' checks')
-      }}
+      @text={{concat @successCount '/' this.total ' ' @type ' checks'}}
       @size="small"
       data-test-health-check-success={{@type}}
     />

--- a/toolkit/src/components/cut/metadata/health-check-badge-set/index.hbs
+++ b/toolkit/src/components/cut/metadata/health-check-badge-set/index.hbs
@@ -7,7 +7,10 @@
     <Hds::Badge
       @color='critical'
       @icon='x'
-      @text={{concat @criticalCount '/' this.total ' ' @type ' checks'}}
+      @text={{if (eq @type 'service-parent') 
+        'Critical'
+        (concat @criticalCount '/' this.total ' ' @type ' checks')
+      }}
       @size="small"
       data-test-health-check-critical={{@type}}
     />
@@ -17,7 +20,10 @@
     <Hds::Badge
       @color='warning'
       @icon='alert-triangle'
-      @text={{concat @warningCount '/' this.total ' ' @type ' checks'}}
+      @text={{if (eq @type 'service-parent') 
+        'Warning'
+        (concat @warningCount '/' this.total ' ' @type ' checks')
+      }}
       @size="small"
       data-test-health-check-warning={{@type}}
     />
@@ -27,7 +33,10 @@
     <Hds::Badge
       @color='success'
       @icon='check'
-      @text={{concat @successCount '/' this.total ' ' @type ' checks'}}
+      @text={{if (eq @type 'service-parent') 
+        'Healthy'
+        (concat @successCount '/' this.total ' ' @type ' checks')
+      }}
       @size="small"
       data-test-health-check-success={{@type}}
     />

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
@@ -15,7 +15,7 @@
       @icon='x'
       @text="Critical"
       @size="small"
-      data-test-health-check-critical-service-parent
+      data-test-service-health-check-critical
     />
   {{else if this.statusIsWarning}}
     <Hds::Badge
@@ -23,7 +23,7 @@
       @icon='alert-triangle'
       @text="Warning"
       @size="small"
-      data-test-health-check-warning-service-parent
+      data-test-service-health-check-warning
     />
   {{else}}
     <Hds::Badge
@@ -31,7 +31,7 @@
       @icon='check'
       @text="Healthy"
       @size="small"
-      data-test-health-check-success-service-parent
+      data-test-service-health-check-healthy
     />
   {{/if}}
 </Hds::TooltipButton>

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
@@ -1,0 +1,37 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+}}
+
+<Hds::TooltipButton 
+  @text={{if 
+    this.statusIsCritical '1 or more instances is critical'
+    (if this.statusIsWarning '1 or more instances has a warning'
+    'All instances are healthy')
+  }} 
+  @placement="bottom-start">
+  {{#if this.statusIsCritical}}
+    <Hds::Badge
+      @color='critical'
+      @icon='x'
+      @text="Critical"
+      @size="small"
+      data-test-health-check-critical-service-parent
+    />
+  {{else if this.statusIsWarning}}
+    <Hds::Badge
+      @color='warning'
+      @icon='alert-triangle'
+      @text="Warning"
+      @size="small"
+      data-test-health-check-warning-service-parent
+    />
+  {{else}}
+    <Hds::Badge
+      @color='success'
+      @icon='check'
+      @text="Healthy"
+      @size="small"
+      data-test-health-check-success-service-parent
+    />
+  {{/if}}
+</Hds::TooltipButton>

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.ts
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.ts
@@ -6,7 +6,6 @@ import Component from '@glimmer/component';
 import { MetadataServiceHealthBadgeSignature } from '../types';
 
 export default class MetadataServiceHealthBadgeComponent extends Component<MetadataServiceHealthBadgeSignature> {
-
   get statusIsCritical() {
     const { criticalCount } = this.args;
     return criticalCount && criticalCount > 0;

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.ts
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
+import Component from '@glimmer/component';
+import { MetadataServiceHealthBadgeSignature } from '../types';
+
+export default class MetadataServiceHealthBadgeComponent extends Component<MetadataServiceHealthBadgeSignature> {
+
+  get statusIsCritical() {
+    const { criticalCount } = this.args;
+    return criticalCount && criticalCount > 0;
+  }
+
+  get statusIsWarning() {
+    const { warningCount } = this.args;
+    return warningCount && warningCount > 0 && !this.statusIsCritical;
+  }
+}

--- a/toolkit/src/components/cut/metadata/types.ts
+++ b/toolkit/src/components/cut/metadata/types.ts
@@ -13,6 +13,14 @@ export interface MetadataHealthCheckBadgeSetSignature {
   };
 }
 
+export interface MetadataServiceHealthBadgeSignature {
+  Args: {
+    successCount?: number;
+    criticalCount?: number;
+    warningCount?: number;
+  };
+}
+
 export interface MetadataExternalSourceSignature {
   Args: {
     externalSource: ExternalSource;


### PR DESCRIPTION
### :hammer_and_wrench: Description
Acceptance Criteria
- If there is more than one critical check, show critical status with a tooltip
- If there is more than one warning, and no critical checks, show warning status with a tooltip
- If there is only passing checks, show healthy status with a tooltip
<!-- What code changed, and why? -->

### :camera_flash: Screenshots
old design:
![image](https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/87380b43-5448-4e44-9805-d66488bcf6dd)

new design:
<img width="1072" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/ac6bcb1e-803c-4c40-b48a-2c2f195cb42f">

Note: these tooltips do actually pop up downwards like this, but when the `ListItem` is in a `PreviewBlock`, there's not enough space so I guess it pops upwards 🤷 
<img width="924" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/5cd08303-fbc7-4543-842a-6b9bf3cf8c10">

<img width="852" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/597fae19-88c0-41f4-baf1-4df7935a0e72">
<img width="852" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/dd30e770-5c6e-4d5f-8a31-0da426d94cfd">
<img width="852" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/6a988fd0-0571-4376-9697-44b600ace0ec">

### :link: External Links
[jira](https://hashicorp.atlassian.net/browse/CC-6223)
<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
