### PR TITLE
Update  FIlterBar Search to use config search value

### DIFF
--- a/.changeset/olive-ducks-fold.md
+++ b/.changeset/olive-ducks-fold.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update `<Cut::FilterBar::Search />` to use search as a value on the search input

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -410,4 +410,20 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
       'Search is updated with the new search value'
     );
   });
+
+  test('if search is set by the config it should prepulate the input', async function (assert) {
+    await setupTest.call(this, {
+      config: {
+        search: { value: 'orange' },
+      },
+    });
+
+    assert.dom('[data-test-search]').hasValue('orange');
+  });
+
+  test('if search is not set by the config it should not prepulate the input', async function (assert) {
+    await setupTest.call(this);
+
+    assert.dom('[data-test-search]').hasNoValue();
+  });
 });

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -5,7 +5,6 @@
 <div class='cut-filter-bar' aria-label='Filter bar'>
   <div class='cut-filter-bar-filters'>
     <div class='cut-filter-bar-filtergroup'>
-
       {{yield
         (hash
           FilterGroup=(component
@@ -42,6 +41,7 @@
           )
           Search=(component
             'cut/filter-bar/search'
+            search=@config.search.value
             onSearchInput=this.onSearchInput
             onSearchKeyup=this.onSearchKeyup
           )

--- a/toolkit/src/components/cut/filter-bar/search.hbs
+++ b/toolkit/src/components/cut/filter-bar/search.hbs
@@ -6,6 +6,7 @@
   {{#let @group as |SG|}}
     <SG.TextInput
       @type='search'
+      @value={{@search}}
       placeholder='Search'
       aria-label='Search'
       {{on 'keyup' @onSearchKeyup}}
@@ -16,6 +17,7 @@
 {{else}}
   <Hds::Form::TextInput::Base
     @type='search'
+    @value={{@search}}
     placeholder='Search'
     aria-label='Search'
     class='cut-filter-bar-search'


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Updates `<Cut::FilterBar::Search />` to use the search value from the filter bar config to populate it's input value. This makes it so that if the search value is read in by the config (for example via query parameters) the search value will update accordingly.

### :camera_flash: Screenshots

https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/489da486-9066-4712-aebe-6e8235e58ffb



### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
https://github.com/hashicorp/cloud-ui/pull/7382

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->


### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
