### PR TITLE
Update SERVICE_KIND to include all service kinds

### DIFF
--- a/.changeset/thirty-ants-tie.md
+++ b/.changeset/thirty-ants-tie.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update SERVICE_KIND to include all service kinds

--- a/documentation/app/controllers/components/service-list-item.js
+++ b/documentation/app/controllers/components/service-list-item.js
@@ -79,6 +79,7 @@ export default class ServiceListItem extends Controller {
             critical: 0,
           },
         },
+        kind: 'typical',
         instanceCount: 8,
         isImported: true,
         samenessGroup: 'group-1',

--- a/documentation/app/templates/components/service-list-item.hbs
+++ b/documentation/app/templates/components/service-list-item.hbs
@@ -115,6 +115,7 @@
                       critical: 0,
                     },
                   },
+                  kind: 'typical',
                   instanceCount: 8,
                   isImported: true,
                   samenessGroup: 'group-1',

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -125,6 +125,40 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
       'renders tags values to metadata'
     );
   });
+
+  test('it does render the kind if it does not find a kindName', async function (assert) {
+    const service = {
+      name: 'Service 1',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 4,
+            critical: 2,
+            warning: 1,
+          },
+        },
+        kind: 'typical',
+        instanceCount: 7,
+        linkedServiceCount: 4,
+        upstreamCount: 4,
+        isImported: true,
+        isPermissiveMTls: true,
+        samenessGroup: 'sameness-group-1',
+        connectedWithGateway: true,
+        externalSource: 'vault',
+        tags: ['tag', 'service'],
+      },
+    };
+    this.set('service', service);
+
+    await render(
+      hbs`
+        <Cut::ListItem::Service @service={{this.service}}/>`
+    );
+
+    assert.false(cutService.metadata.kind.renders, 'kind');
+  });
+
   test('it renders Cut::ListItem::Service without metadata', async function (assert) {
     const service = {
       name: 'Service 1',

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -25,7 +25,7 @@
             @warningCount={{@service.metadata.healthCheck.instance.warning}}
             @criticalCount={{@service.metadata.healthCheck.instance.critical}}
           />
-          {{#if @service.metadata.kind}}
+          {{#if this.kindName}}
             <Cut::TextWithIcon
               @icon='gateway'
               @text={{this.kindName}}

--- a/toolkit/src/components/cut/list-item/service/index.ts
+++ b/toolkit/src/components/cut/list-item/service/index.ts
@@ -28,6 +28,15 @@ export default class ServiceListItemComponent extends Component<ServiceListItemS
 
   get kindName() {
     const { kind } = this.args.service.metadata;
-    return kind ? this.NormalizedGatewayLabels[kind] : undefined;
+    return kind &&
+      Object.prototype.hasOwnProperty.call(this.NormalizedGatewayLabels, kind)
+      ? this.NormalizedGatewayLabels[
+          kind as
+            | 'api-gateway'
+            | 'mesh-gateway'
+            | 'ingress-gateway'
+            | 'terminating-gateway'
+        ]
+      : undefined;
   }
 }

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -106,6 +106,10 @@ export type ExternalSource =
   | 'lambda';
 
 export type SERVICE_KIND =
+  | ''
+  | 'typical'
+  | 'destination'
+  | 'connect-proxy'
   | 'api-gateway'
   | 'mesh-gateway'
   | 'ingress-gateway'


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Updates `SERVICE_KIND` to include all the service types and updates showing the kind to be based on if the `kindName` is found. Functionally, this doesn't change anything, but now we can just always pass in the service kind that is returned from the API instead of altering it in the consuming app.

Reference API PR: https://github.com/hashicorp/cloud-global-network-manager-service/pull/987

### :camera_flash: Screenshots

<img width="917" alt="Screenshot 2023-09-06 at 10 58 56 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/94054455-e96b-4b76-98a1-2426f8a43084">

<img width="1670" alt="Screenshot 2023-09-06 at 11 07 40 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/13eb6bcd-d034-411e-b746-b4f9af8e86cf">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
https://github.com/hashicorp/cloud-global-network-manager-service/pull/987

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
