### PR TITLE
Remove utils re-export

### DIFF
--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -127,9 +127,7 @@
       "./components/cut/metadata/types.js": "./dist/_app_/components/cut/metadata/types.js",
       "./components/cut/text-with-icon/index.js": "./dist/_app_/components/cut/text-with-icon/index.js",
       "./components/cut/text-with-icon/types.js": "./dist/_app_/components/cut/text-with-icon/types.js",
-      "./helpers/titlecase.js": "./dist/_app_/helpers/titlecase.js",
-      "./utils/index.js": "./dist/_app_/utils/index.js",
-      "./utils/service-list-item.js": "./dist/_app_/utils/service-list-item.js"
+      "./helpers/titlecase.js": "./dist/_app_/helpers/titlecase.js"
     }
   },
   "exports": {

--- a/toolkit/rollup.config.mjs
+++ b/toolkit/rollup.config.mjs
@@ -28,7 +28,7 @@ export default {
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/**/*.js', 'helpers/**/*.js', 'utils/*.js']),
+    addon.appReexports(['components/**/*.js', 'helpers/**/*.js']),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

This already didn't have a default export so it was causing issues in embroider builds. All the utils are avalable via the main index export as it is. 

### :camera_flash: Screenshots

### :link: External Links
#62 

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
