### PR TITLE
CC-6362: pass route info to pagination

### DIFF
--- a/.changeset/tall-windows-allow.md
+++ b/.changeset/tall-windows-allow.md
@@ -1,0 +1,6 @@
+---
+'@hashicorp/consul-ui-toolkit': minor
+---
+
+Add model/models/replace to `Cut::List::Pagination`
+Update type for replace & query

--- a/documentation/app/routes/components/list.js
+++ b/documentation/app/routes/components/list.js
@@ -7,7 +7,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 export default class ListRoute extends Route {
   queryParams = {
-    page: {
+    nextPage: {
+      refreshModel: true,
+    },
+    previousPage: {
       refreshModel: true,
     },
     pageSize: {

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -8,8 +8,8 @@ export interface ListItemSignature {
     isHrefExternal?: boolean;
     route?: string;
     isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
+    query?: unknown;
+    replace?: boolean;
     model?: string | unknown;
     models?: string[] | unknown[];
     onClick(): void;
@@ -23,8 +23,8 @@ export interface ServiceInstanceListItemSignature {
     isHrefExternal?: boolean;
     route?: string;
     isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
+    query?: unknown;
+    replace?: boolean;
     model?: string | unknown;
     models?: string[] | unknown[];
     onClick(): void;
@@ -41,8 +41,8 @@ export interface ServiceListItemSignature {
     isHrefExternal?: boolean;
     route?: string;
     isRouteExternal?: boolean;
-    query?: object;
-    replace?: string;
+    query?: unknown;
+    replace?: boolean;
     model?: string | unknown;
     models?: string[] | unknown[];
     onClick(): void;

--- a/toolkit/src/components/cut/list/pagination.hbs
+++ b/toolkit/src/components/cut/list/pagination.hbs
@@ -17,6 +17,9 @@
       @showLabels={{true}}
       @queryFunction={{this.queryFunction}}
       @route={{or @route this.router.currentRouteName}}
+      @model={{@model}}
+      @models={{@models}}
+      @replace={{@replace}}
       @isDisabledPrev={{not @prevCursor}}
       @isDisabledNext={{not @nextCursor}}
     />

--- a/toolkit/src/components/cut/list/types.ts
+++ b/toolkit/src/components/cut/list/types.ts
@@ -8,6 +8,9 @@ export interface PaginationSignature {
     prevCursor?: string;
     pageSizes?: number[];
     currentPageSize?: number;
+    model?: string | unknown;
+    models?: string[] | unknown[];
+    replace?: boolean;
     queryFunction?: (page: string) => {
       [key: string]: string | number | unknown;
     };


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
The pagination component should be able to pass in all the route info the [HDS::Pagination::Compact](https://helios.hashicorp.design/components/pagination?tab=code#paginationcompact) allows. It was missing `model/models/replace`. Being able to specify the model will let us do route based pagination with this component on routes that have dynamic params based on the model. 

I also update the types of replace to `boolean` as that is what is expected and `query` to just be `unknown`

The docs update isn't related to this specific change but a change I made a while ago to set `previousPage` or `nestPage` query params when doing route based pagination. 

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-6362](https://hashicorp.atlassian.net/browse/CC-6362)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-6362]: https://hashicorp.atlassian.net/browse/CC-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ