### PR TITLE
CC-5575: Update filter-bar results text for searching

### DIFF
--- a/.changeset/late-dots-heal.md
+++ b/.changeset/late-dots-heal.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update filter-bar results text to show searching text if only search is applied

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -345,6 +345,48 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
     assert.dom('[data-test-filter-bar-results]').hasText('Filters applied:');
   });
 
+  test('shows filters applied text when there are filters applied and search is applied and no count is passed in', async function (assert) {
+    await setupTest.call(this, {
+      name: 'nacho',
+      config: {
+        search: { value: 'boom' },
+        filters: {
+          status: [
+            {
+              text: 'Running',
+              value: 'running',
+            },
+          ],
+        },
+      },
+    });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Filters applied:');
+  });
+
+  test('shows default searching text when there are no filters applied and search is applied no count is passed in', async function (assert) {
+    await setupTest.call(this, {
+      config: {
+        search: { value: 'bloom' },
+      },
+    });
+
+    assert.dom('[data-test-filter-bar-results]').hasText('Searching');
+  });
+
+  test('shows searching text with the name when there are no filters applied and search is applied no count is passed in and the name is set', async function (assert) {
+    await setupTest.call(this, {
+      name: 'Service Instance',
+      config: {
+        search: { value: 'bloom' },
+      },
+    });
+
+    assert
+      .dom('[data-test-filter-bar-results]')
+      .hasText('Searching Service Instances');
+  });
+
   test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {
     await setupTest.call(this, { config: {}, count: 3 });
 

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -83,6 +83,8 @@
         }}
       {{else if this.isFiltering}}
         Filters applied:
+      {{else if this.isSearching}}
+        Searching{{if @name (concat ' ' (pluralize @name))}}
       {{else}}
         Showing all
         {{if @name (pluralize @name) 'results'}}

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -113,6 +113,10 @@ export default class FilterBarComponent extends Component<FilterBarSignature> {
     return Object.keys(this.args.config?.filters || {}).length > 0;
   }
 
+  get isSearching(): boolean {
+    return !!this.args.config?.search?.value;
+  }
+
   isChecked(localConfig: FilterConfig, filter: string, value: unknown) {
     if (Array.isArray(localConfig?.filters?.[filter])) {
       return !!(localConfig?.filters?.[filter] as Filter[]).find(


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Updates `Cut::FilterBar` results text to show `Searching` or `Searching ${name}` if it is searching without filters. 

### :camera_flash: Screenshots
Brought this over to the linked branch with yalc to test it out
<img width="2309" alt="Screenshot 2023-09-20 at 9 22 14 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/dcec8f06-2f1c-487a-a99c-00452a9fe812">
<img width="2309" alt="Screenshot 2023-09-20 at 9 22 07 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/85cd9802-22d9-4fc9-85ae-c256ae0c34c1">
<img width="2309" alt="Screenshot 2023-09-20 at 9 21 59 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/352eecb3-8994-4541-9556-3b11272c4a24">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
https://github.com/hashicorp/cloud-ui/pull/7580

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
