### PR TITLE
CC-6361: Add cluster path to service list item

### DIFF
--- a/.changeset/short-avocados-bathe.md
+++ b/.changeset/short-avocados-bathe.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': minor
+---
+
+Service list item now includes cluster ID, partition, and namespace info

--- a/documentation/app/controllers/components/list.js
+++ b/documentation/app/controllers/components/list.js
@@ -30,6 +30,9 @@ export default class ListController extends Controller {
         kind: SERVICE_GATEWAY_TYPE.IngressGateway,
         upstreamCount: 5,
         tags: ['monitor', 'array', 'monitor'],
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
   }

--- a/documentation/app/controllers/components/service-list-item.js
+++ b/documentation/app/controllers/components/service-list-item.js
@@ -28,6 +28,9 @@ export default class ServiceListItem extends Controller {
         kind: SERVICE_GATEWAY_TYPE.IngressGateway,
         upstreamCount: 5,
         tags: ['monitor', 'array', 'monitor'],
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
   }
@@ -46,6 +49,9 @@ export default class ServiceListItem extends Controller {
         externalSource: 'consul',
         instanceCount: 3,
         tags: ['consul', 'array', 'monitor'],
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
   }
@@ -64,6 +70,9 @@ export default class ServiceListItem extends Controller {
         kind: SERVICE_GATEWAY_TYPE.TerminatingGateway,
         linkedServiceCount: 6,
         externalSource: 'vault',
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
   }
@@ -84,6 +93,9 @@ export default class ServiceListItem extends Controller {
         isImported: true,
         samenessGroup: 'group-1',
         isPermissiveMTls: true,
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
   }

--- a/documentation/app/templates/components/service-list-item.hbs
+++ b/documentation/app/templates/components/service-list-item.hbs
@@ -174,6 +174,9 @@
               tags: string[];
               upstreamCount?: number;
               linkedServiceCount?: number;
+              clusterId: string | undefined;
+              partition?: string;
+              namespace?: string;
             };
           }
           "}}}
@@ -317,6 +320,22 @@
           metadata.
         </ComponentApi>
 
+        <ComponentApi
+          @name="service.metadata.clusterId"
+          @isRequired={{true}}
+          @type="string"
+        >The unique identifier of the Consul cluster the service is registered with.</ComponentApi>
+        <ComponentApi
+          @name="service.metadata.partition"
+          @isRequired={{false}}
+          @type="string"
+        >The partition where the service is deployed.</ComponentApi>
+        <ComponentApi
+          @name="service.metadata.namespace"
+          @isRequired={{false}}
+          @type="string"
+        >The namespace where the service is deployed.</ComponentApi>
+
         <h4 id="health-check">Health check</h4>
         The
         <CodeInline @code="service.metadata.healthCheck" />
@@ -348,12 +367,18 @@
           <CodeInline @code="critical" />
           status.</ComponentApi>
 
+        <h3 id="options">Options</h3>
+          <ComponentApi @name="hideClusterPath" @type="boolean">
+            Determines whether the cluster ID, partition, and namespace are displayed in the Service List Item. Default value is <CodeInline @code="false" />.
+          </ComponentApi>
+
       </div>
       <InPageNav as |I|>
         <I.Link @section="#component-api">Component API</I.Link>
         <I.Link @section="#service" @depth={{2}}>Service</I.Link>
         <I.Link @section="#metadata" @depth={{2}}>Metadata</I.Link>
         <I.Link @section="#health-check" @depth={{2}}>Health check</I.Link>
+        <I.Link @section="#options" @depth={{2}}>Options</I.Link>
       </InPageNav>
     </div>
   </T.Panel>

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -38,6 +38,9 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
         connectedWithGateway: true,
         externalSource: 'vault',
         tags: ['tag', 'service'],
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
       },
     };
     this.set('service', service);
@@ -47,7 +50,13 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
         <Cut::ListItem::Service @service={{this.service}}/>`
     );
     assert.true(cutService.renders, 'renders component');
-    assert.deepEqual(cutService.title, 'Service 1', 'service name is set');
+    assert.true(cutService.title.includes('Service 1'), 'service name is set');
+
+    assert.true(cutService.clusterPath.renders, 'renders cluster path');
+    assert.true(cutService.clusterPath.text.includes('self-managed-cluster'), 'cluster ID is set');
+    assert.true(cutService.clusterPath.text.includes('partition'), 'partition is set');
+    assert.true(cutService.clusterPath.text.includes('namespace'), 'namespace is set');
+
     assert.false(
       cutService.metadata.healthCheck.healthy.renders,
       'healthy status badge does not render if there are warning or critical healthchecks'
@@ -175,7 +184,9 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
         <Cut::ListItem::Service @service={{this.service}}/>`
     );
     assert.true(cutService.renders, 'renders');
-    assert.deepEqual(cutService.title, 'Service 1', 'service name is set');
+    assert.true(cutService.title.includes('Service 1'), 'service name is set');
+    assert.false(cutService.clusterPath.renders, 'does not render cluster path');
+
     assert.true(
       cutService.metadata.healthCheck.healthy.renders,
       'renders healthy status badge'

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -53,9 +53,18 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     assert.true(cutService.title.includes('Service 1'), 'service name is set');
 
     assert.true(cutService.clusterPath.renders, 'renders cluster path');
-    assert.true(cutService.clusterPath.text.includes('self-managed-cluster'), 'cluster ID is set');
-    assert.true(cutService.clusterPath.text.includes('partition'), 'partition is set');
-    assert.true(cutService.clusterPath.text.includes('namespace'), 'namespace is set');
+    assert.true(
+      cutService.clusterPath.text.includes('self-managed-cluster'),
+      'cluster ID is set'
+    );
+    assert.true(
+      cutService.clusterPath.text.includes('partition'),
+      'partition is set'
+    );
+    assert.true(
+      cutService.clusterPath.text.includes('namespace'),
+      'namespace is set'
+    );
 
     assert.false(
       cutService.metadata.healthCheck.healthy.renders,
@@ -170,8 +179,10 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     assert.true(cutService.renders, 'renders component');
     assert.true(cutService.title.includes('Service 1'), 'service name is set');
 
-    debugger;
-    assert.false(cutService.clusterPath.renders, 'does not render cluster path');
+    assert.false(
+      cutService.clusterPath.renders,
+      'does not render cluster path'
+    );
   });
 
   test('it does render the kind if it does not find a kindName', async function (assert) {
@@ -224,7 +235,10 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     );
     assert.true(cutService.renders, 'renders');
     assert.true(cutService.title.includes('Service 1'), 'service name is set');
-    assert.false(cutService.clusterPath.renders, 'does not render cluster path');
+    assert.false(
+      cutService.clusterPath.renders,
+      'does not render cluster path'
+    );
 
     assert.true(
       cutService.metadata.healthCheck.healthy.renders,

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -135,6 +135,45 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     );
   });
 
+  test('it does not render cluster path if specified ', async function (assert) {
+    const service = {
+      name: 'Service 1',
+      metadata: {
+        healthCheck: {
+          instance: {
+            success: 4,
+            critical: 2,
+            warning: 1,
+          },
+        },
+        kind: 'mesh-gateway',
+        instanceCount: 7,
+        linkedServiceCount: 4,
+        upstreamCount: 4,
+        isImported: true,
+        isPermissiveMTls: true,
+        samenessGroup: 'sameness-group-1',
+        connectedWithGateway: true,
+        externalSource: 'vault',
+        tags: ['tag', 'service'],
+        clusterId: 'self-managed-cluster',
+        partition: 'partition',
+        namespace: 'namespace',
+      },
+    };
+    this.set('service', service);
+
+    await render(
+      hbs`
+        <Cut::ListItem::Service @service={{this.service}} @hideClusterPath={{true}}/>`
+    );
+    assert.true(cutService.renders, 'renders component');
+    assert.true(cutService.title.includes('Service 1'), 'service name is set');
+
+    debugger;
+    assert.false(cutService.clusterPath.renders, 'does not render cluster path');
+  });
+
   test('it does render the kind if it does not find a kindName', async function (assert) {
     const service = {
       name: 'Service 1',

--- a/documentation/tests/pages/service-list-item.js
+++ b/documentation/tests/pages/service-list-item.js
@@ -9,6 +9,10 @@ const listItemSelector = '[data-test-service-list-item]';
 export default create({
   renders: isPresent(listItemSelector),
   title: text(`${listItemSelector} [data-test-service-name]`),
+  clusterPath: {
+    renders: isPresent(`${listItemSelector} [data-test-service-cluster-path]`),
+    text: text(`${listItemSelector} [data-test-service-cluster-path]`),
+  },
   metadata: {
     healthCheck: {
       healthy: {

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -119,6 +119,7 @@
       "./components/cut/list/index.js": "./dist/_app_/components/cut/list/index.js",
       "./components/cut/list/pagination.js": "./dist/_app_/components/cut/list/pagination.js",
       "./components/cut/list/types.js": "./dist/_app_/components/cut/list/types.js",
+      "./components/cut/metadata/cluster-path/index.js": "./dist/_app_/components/cut/metadata/cluster-path/index.js",
       "./components/cut/metadata/external-source/index.js": "./dist/_app_/components/cut/metadata/external-source/index.js",
       "./components/cut/metadata/health-check-badge-set/index.js": "./dist/_app_/components/cut/metadata/health-check-badge-set/index.js",
       "./components/cut/metadata/in-service-mesh/index.js": "./dist/_app_/components/cut/metadata/in-service-mesh/index.js",

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -20,11 +20,13 @@
       <T.Section as |SC|>
         <SC.Title data-test-service-name>
           {{@service.name}}
-          <Cut::Metadata::ClusterPath
-            @clusterId={{@service.metadata.clusterId}}
-            @partition={{@service.metadata.partition}}
-            @namespace={{@service.metadata.namespace}}
-          />
+          {{#unless @hideClusterPath}}
+            <Cut::Metadata::ClusterPath
+              @clusterId={{@service.metadata.clusterId}}
+              @partition={{@service.metadata.partition}}
+              @namespace={{@service.metadata.namespace}}
+            />
+          {{/unless}}
         </SC.Title>
         <SC.Metadata>
           <Cut::Metadata::ServiceHealthBadge

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -18,7 +18,14 @@
   <L.Content as |C|>
     <Cut::ListItem::Template as |T|>
       <T.Section as |SC|>
-        <SC.Title data-test-service-name>{{@service.name}}</SC.Title>
+        <SC.Title data-test-service-name>
+          {{@service.name}}
+          <Cut::Metadata::ClusterPath
+            @clusterId={{@service.metadata.clusterId}}
+            @partition={{@service.metadata.partition}}
+            @namespace={{@service.metadata.namespace}}
+          />
+        </SC.Title>
         <SC.Metadata>
           <Cut::Metadata::ServiceHealthBadge
             @successCount={{@service.metadata.healthCheck.instance.success}}

--- a/toolkit/src/components/cut/list-item/types.ts
+++ b/toolkit/src/components/cut/list-item/types.ts
@@ -49,6 +49,7 @@ export interface ServiceListItemSignature {
 
     // Service args
     service: CutService;
+    hideClusterPath?: boolean;
   };
 }
 

--- a/toolkit/src/components/cut/metadata/cluster-path/index.hbs
+++ b/toolkit/src/components/cut/metadata/cluster-path/index.hbs
@@ -1,0 +1,33 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+}}
+
+<div class='cut-service-cluster-path'>
+  <span class="hds-link-inline__icon hds-link-inline__icon--leading">
+    <FlightIcon @name="server-cluster" @size="16" @stretched={{true}} />
+  </span>
+  {{@clusterId}}
+
+  <span
+    class="hds-link-inline__icon hds-link-inline__icon--leading cluster-path-separator"
+  >
+    <FlightIcon @name="chevron-right" @size="16" @stretched={{true}} />
+  </span>
+
+  <span class="hds-link-inline__icon hds-link-inline__icon--leading">
+    <FlightIcon @name="users" @size="16" @stretched={{true}} />
+  </span>
+  {{@partition}}
+
+  <span
+    class="hds-link-inline__icon hds-link-inline__icon--leading cluster-path-separator"
+  >
+    <FlightIcon @name="chevron-right" @size="16" @stretched={{true}} />
+  </span>
+
+  <span class="hds-link-inline__icon hds-link-inline__icon--leading">
+    <FlightIcon @name="folder-users" @size="16" @stretched={{true}} />
+  </span>
+  {{@namespace}}
+
+</div>

--- a/toolkit/src/components/cut/metadata/cluster-path/index.hbs
+++ b/toolkit/src/components/cut/metadata/cluster-path/index.hbs
@@ -2,7 +2,8 @@
   Copyright (c) HashiCorp, Inc.
 }}
 
-<div class='cut-service-cluster-path'>
+{{#if (and (and @clusterId @partition) @namespace)}}
+<div class="cut-service-cluster-path" data-test-service-cluster-path>
   <span class="hds-link-inline__icon hds-link-inline__icon--leading">
     <FlightIcon @name="server-cluster" @size="16" @stretched={{true}} />
   </span>
@@ -29,5 +30,5 @@
     <FlightIcon @name="folder-users" @size="16" @stretched={{true}} />
   </span>
   {{@namespace}}
-
 </div>
+{{/if}}

--- a/toolkit/src/components/cut/metadata/cluster-path/index.ts
+++ b/toolkit/src/components/cut/metadata/cluster-path/index.ts
@@ -10,4 +10,5 @@ interface Args {
   namespace: string;
 }
 
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class MetadataClusterPathComponent extends Component<Args> {}

--- a/toolkit/src/components/cut/metadata/cluster-path/index.ts
+++ b/toolkit/src/components/cut/metadata/cluster-path/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ */
+
+import Component from '@glimmer/component';
+
+interface Args {
+  clusterId: string;
+  partition: string;
+  namespace: string;
+}
+
+export default class MetadataClusterPathComponent extends Component<Args> {}

--- a/toolkit/src/styles/@hashicorp/consul-ui-toolkit.scss
+++ b/toolkit/src/styles/@hashicorp/consul-ui-toolkit.scss
@@ -7,3 +7,4 @@
 @use '../components/copy-block';
 @use '../components/filter-bar';
 @use '../components/list';
+@use '../components/cluster-path';

--- a/toolkit/src/styles/components/cluster-path.scss
+++ b/toolkit/src/styles/components/cluster-path.scss
@@ -8,8 +8,8 @@
 
 .cut-service-cluster-path {
   color: var(--token-color-foreground-faint);
-  font-size: 14px;
-  font-weight: 400;
+  font-size: var(--token-typography-body-200-font-size);
+  font-weight: var(--token-typography-font-weight-regular);
   display: flex;
   align-items: center;
   gap: 4px;

--- a/toolkit/src/styles/components/cluster-path.scss
+++ b/toolkit/src/styles/components/cluster-path.scss
@@ -1,0 +1,17 @@
+/**
+* Copyright (c) HashiCorp, Inc.
+*/
+
+.cluster-path-separator {
+  color: var(--token-color-palette-neutral-300);
+}
+
+.cut-service-cluster-path {
+  color: var(--token-color-foreground-faint);
+  font-size: 14px;
+  font-weight: 400;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 4px;
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description
Since there can be multiple services with the same name, we should also show the `cluster ID`, `partition`, and `namespace` to uniquely identify a service.

This only applies for HCP Consul and not Consul UI, so an option is added to hide the cluster path.
<!-- What code changed, and why? -->

### :camera_flash: Screenshots
<img width="678" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/632a373b-029d-4561-86e3-46d970eab26a">


it does spill over if the strings are too long, but it should be fine for now? as long as the user mades it wide enough

<img width="678" alt="image" src="https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/2c10fc91-2ff2-4986-8150-885e74573bcd">


### :link: External Links
[jira](https://hashicorp.atlassian.net/browse/CC-6361)
<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
