### PR TITLE
CC-6218: list item template styling and strict mtls icon

### DIFF
--- a/.changeset/brave-carpets-vanish.md
+++ b/.changeset/brave-carpets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update list-item-template styling and add strict mtls badge to list item metadata

--- a/documentation/app/controllers/components/service-list-item.js
+++ b/documentation/app/controllers/components/service-list-item.js
@@ -46,6 +46,7 @@ export default class ServiceListItem extends Controller {
         externalSource: 'consul',
         instanceCount: 3,
         tags: ['consul', 'array', 'monitor'],
+        isPermissiveMTls: false,
       },
     };
   }

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -97,6 +97,10 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
       cutService.metadata.isPermissiveMTls,
       'renders permissive mtls'
     );
+    assert.false(
+      cutService.metadata.isStrictMTls,
+      'does not render strict mtls'
+    );
     assert.true(cutService.metadata.isImported, 'renders imported');
     assert.true(
       cutService.metadata.samenessGroup.renders,
@@ -191,7 +195,14 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     );
     assert.false(cutService.metadata.upstreamCount.renders, 'upstream count');
     assert.false(cutService.metadata.inMeshGateway.renders, 'mesh data');
-    assert.false(cutService.metadata.isPermissiveMTls, 'permissive mTLS');
+    assert.false(
+      cutService.metadata.isPermissiveMTls,
+      'permissive mTLS does not render'
+    );
+    assert.false(
+      cutService.metadata.isStrictMTls,
+      'strict mTLS does not render'
+    );
     assert.false(cutService.metadata.isImported, 'imported');
     assert.false(cutService.metadata.samenessGroup.renders, 'sameness group');
     assert.false(
@@ -261,6 +272,7 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
         // adding intentionally to check if it will be rendered
         instanceCount: 3,
         upstreamCount: 5,
+        isPermissiveMTls: false,
       },
     };
     this.set('service', service);
@@ -284,5 +296,12 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
       cutService.metadata.instanceCount.renders,
       'does not render instance count'
     );
+
+    assert.false(
+      cutService.metadata.isPermissiveMTls,
+      'permissive mTLS does not render'
+    );
+
+    assert.true(cutService.metadata.isStrictMTls, 'strict mTLS renders');
   });
 });

--- a/documentation/tests/integration/components/service-list-item-test.js
+++ b/documentation/tests/integration/components/service-list-item-test.js
@@ -176,9 +176,9 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     );
     assert.true(cutService.renders, 'renders');
     assert.deepEqual(cutService.title, 'Service 1', 'service name is set');
-    assert.true(
+    assert.false(
       cutService.metadata.healthCheck.healthy.renders,
-      'renders healthy status badge'
+      'does not render healthy status badge'
     );
 
     assert.false(cutService.metadata.healthCheck.critical.renders, 'critical');
@@ -234,6 +234,19 @@ module('Integration | Component | cut/list-item/service', function (hooks) {
     assert.false(
       cutService.metadata.linkedServiceCount.renders,
       'does not render linked service count'
+    );
+
+    assert.false(
+      cutService.metadata.healthCheck.healthy.renders,
+      'It does not render a health status'
+    );
+    assert.false(
+      cutService.metadata.healthCheck.warning.renders,
+      'It does not render a health status'
+    );
+    assert.false(
+      cutService.metadata.healthCheck.critical.renders,
+      'It does not render a health status'
     );
   });
   test('it renders linked service count instead of instance count/upstream count for kind terminating-gateway', async function (assert) {

--- a/documentation/tests/pages/service-list-item.js
+++ b/documentation/tests/pages/service-list-item.js
@@ -7,76 +7,58 @@ import { create, isPresent, text } from 'ember-cli-page-object';
 
 const listItemSelector = '[data-test-service-list-item]';
 export default create({
-  renders: isPresent(listItemSelector),
-  title: text(`${listItemSelector} [data-test-service-name]`),
+  scope: listItemSelector,
+  renders: isPresent(),
+  title: text(`[data-test-service-name]`),
   metadata: {
     healthCheck: {
       healthy: {
-        renders: isPresent(
-          `${listItemSelector} [data-test-service-health-check-healthy]`
-        ),
-        text: text(
-          `${listItemSelector} [data-test-service-health-check-healthy]`
-        ),
+        renders: isPresent(`[data-test-service-health-check-healthy]`),
+        text: text(`[data-test-service-health-check-healthy]`),
       },
       critical: {
-        renders: isPresent(
-          `${listItemSelector} [data-test-service-health-check-critical]`
-        ),
-        text: text(
-          `${listItemSelector} [data-test-service-health-check-critical]`
-        ),
+        renders: isPresent(`[data-test-service-health-check-critical]`),
+        text: text(`[data-test-service-health-check-critical]`),
       },
       warning: {
-        renders: isPresent(
-          `${listItemSelector} [data-test-service-health-check-warning]`
-        ),
-        text: text(
-          `${listItemSelector} [data-test-service-health-check-warning]`
-        ),
+        renders: isPresent(`[data-test-service-health-check-warning]`),
+        text: text(`[data-test-service-health-check-warning]`),
       },
     },
     kind: {
-      renders: isPresent(`${listItemSelector} [data-test-service-kind]`),
-      text: text(`${listItemSelector} [data-test-service-kind]`),
+      renders: isPresent(`[data-test-service-kind]`),
+      text: text(`[data-test-service-kind]`),
     },
     instanceCount: {
-      renders: isPresent(
-        `${listItemSelector} [data-test-associated-instance-count]`
-      ),
-      text: text(`${listItemSelector} [data-test-associated-instance-count]`),
+      renders: isPresent(`[data-test-associated-instance-count]`),
+      text: text(`[data-test-associated-instance-count]`),
     },
     linkedServiceCount: {
-      renders: isPresent(
-        `${listItemSelector} [data-test-associated-service-count]`
-      ),
-      text: text(`${listItemSelector} [data-test-associated-service-count]`),
+      renders: isPresent(`[data-test-associated-service-count]`),
+      text: text(`[data-test-associated-service-count]`),
     },
     upstreamCount: {
-      renders: isPresent(
-        `${listItemSelector} [data-test-associated-upstream-count]`
-      ),
-      text: text(`${listItemSelector} [data-test-associated-upstream-count]`),
+      renders: isPresent(`[data-test-associated-upstream-count]`),
+      text: text(`[data-test-associated-upstream-count]`),
     },
     inMeshGateway: {
-      renders: isPresent(`${listItemSelector} [data-test-mesh]`),
-      text: text(`${listItemSelector} [data-test-mesh]`),
+      renders: isPresent(`[data-test-mesh]`),
+      text: text(`[data-test-mesh]`),
     },
-    isPermissiveMTls: isPresent(
-      `${listItemSelector} [data-test-permissive-mtls]`
-    ),
+    isPermissiveMTls: isPresent(`[data-test-permissive-mtls]`),
+    isStrictMTls: isPresent(`[data-test-strict-mtls]`),
     samenessGroup: {
-      renders: isPresent(`${listItemSelector} [data-test-sameness-group]`),
-      text: text(`${listItemSelector} [data-test-sameness-group]`),
+      renders: isPresent(`[data-test-sameness-group]`),
+      text: text(`[data-test-sameness-group]`),
     },
-    isImported: isPresent(`${listItemSelector} [data-test-imported]`),
+    isImported: isPresent(`[data-test-imported]`),
     externalSource: {
-      renders: isPresent(`${listItemSelector} [data-test-external-source]`),
-      text: text(`${listItemSelector} [data-test-external-source]`),
+      renders: isPresent(`[data-test-external-source]`),
+      text: text(`[data-test-external-source]`),
     },
     tags: {
-      renders: isPresent(`${listItemSelector} [data-test-tags]`),
-      text: text(`${listItemSelector} [data-test-tags]`),
+      renders: isPresent(`[data-test-tags]`),
+      text: text(`[data-test-tags]`),
     },
   },
 });

--- a/toolkit/src/components/cut/list-item/section/metadata.hbs
+++ b/toolkit/src/components/cut/list-item/section/metadata.hbs
@@ -3,6 +3,6 @@
 }}
 
 <div
-  class='cut-list-item-section__metadata hds-typography-body-200 hds-font-weight-regular'
+  class='cut-list-item-section__metadata hds-typography-display-100 hds-font-weight-regular'
   ...attributes
 >{{yield}}</div>

--- a/toolkit/src/components/cut/list-item/section/title.hbs
+++ b/toolkit/src/components/cut/list-item/section/title.hbs
@@ -3,6 +3,6 @@
 }}
 
 <div
-  class='cut-list-item-section__title hds-typography-body-300 hds-font-weight-semibold'
+  class='cut-list-item-section__title hds-typography-body-200 hds-font-weight-semibold'
   ...attributes
 >{{yield}}</div>

--- a/toolkit/src/components/cut/list-item/service/index.hbs
+++ b/toolkit/src/components/cut/list-item/service/index.hbs
@@ -61,6 +61,17 @@
               @text='permissive mTLS'
               data-test-permissive-mtls
             />
+          {{else if
+            (and
+              (eq @service.metadata.isPermissiveMTls false)
+              (not (eq @service.metadata.isPermissiveMTls undefined))
+            )
+          }}
+            <Cut::TextWithIcon
+              @icon='lock'
+              @text='strict mTLS'
+              data-test-strict-mtls
+            />
           {{/if}}
           <Cut::Metadata::InServiceMesh
             @connectedWithGateway={{@service.metadata.connectedWithGateway}}

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.hbs
@@ -2,36 +2,40 @@
   Copyright (c) HashiCorp, Inc.
 }}
 
-<Hds::TooltipButton 
-  @text={{if 
-    this.statusIsCritical '1 or more instances is critical'
-    (if this.statusIsWarning '1 or more instances has a warning'
-    'All instances are healthy')
-  }} 
-  @placement="bottom-start">
-  {{#if this.statusIsCritical}}
-    <Hds::Badge
-      @color='critical'
-      @icon='x'
-      @text="Critical"
-      @size="small"
-      data-test-service-health-check-critical
-    />
-  {{else if this.statusIsWarning}}
-    <Hds::Badge
-      @color='warning'
-      @icon='alert-triangle'
-      @text="Warning"
-      @size="small"
-      data-test-service-health-check-warning
-    />
-  {{else}}
-    <Hds::Badge
-      @color='success'
-      @icon='check'
-      @text="Healthy"
-      @size="small"
-      data-test-service-health-check-healthy
-    />
-  {{/if}}
-</Hds::TooltipButton>
+{{#if this.hasStatus}}
+  <Hds::TooltipButton
+    @text={{if
+      this.statusIsCritical
+      '1 or more instances is critical'
+      (if
+        this.statusIsWarning
+        '1 or more instances has a warning'
+        'All instances are healthy'
+      )
+    }}
+    @placement='bottom-start'
+  >
+    {{#if this.statusIsCritical}}
+      <Hds::Badge
+        @color='critical'
+        @icon='x'
+        @text='Critical'
+        data-test-service-health-check-critical
+      />
+    {{else if this.statusIsWarning}}
+      <Hds::Badge
+        @color='warning'
+        @icon='alert-triangle'
+        @text='Warning'
+        data-test-service-health-check-warning
+      />
+    {{else}}
+      <Hds::Badge
+        @color='success'
+        @icon='check'
+        @text='Healthy'
+        a-test-service-health-check-healthy
+      />
+    {{/if}}
+  </Hds::TooltipButton>
+{{/if}}

--- a/toolkit/src/components/cut/metadata/service-health-badge/index.ts
+++ b/toolkit/src/components/cut/metadata/service-health-badge/index.ts
@@ -6,13 +6,19 @@ import Component from '@glimmer/component';
 import { MetadataServiceHealthBadgeSignature } from '../types';
 
 export default class MetadataServiceHealthBadgeComponent extends Component<MetadataServiceHealthBadgeSignature> {
-  get statusIsCritical() {
-    const { criticalCount } = this.args;
-    return criticalCount && criticalCount > 0;
+  get hasStatus(): boolean {
+    const { criticalCount, warningCount, successCount } = this.args;
+
+    return !!criticalCount || !!warningCount || !!successCount;
   }
 
-  get statusIsWarning() {
+  get statusIsCritical(): boolean {
+    const { criticalCount } = this.args;
+    return !!criticalCount && criticalCount > 0;
+  }
+
+  get statusIsWarning(): boolean {
     const { warningCount } = this.args;
-    return warningCount && warningCount > 0 && !this.statusIsCritical;
+    return !!warningCount && warningCount > 0 && !this.statusIsCritical;
   }
 }

--- a/toolkit/src/components/cut/text-with-icon/index.hbs
+++ b/toolkit/src/components/cut/text-with-icon/index.hbs
@@ -2,10 +2,13 @@
   Copyright (c) HashiCorp, Inc.
 }}
 
-<div class="cut-text-with-icon" ...attributes>
-  <FlightIcon @name={{@icon}} @size="16" @color={{@iconColor}}/>
+<div
+  class='cut-text-with-icon hds-typography-body-100 hds-font-weight-regular'
+  ...attributes
+>
+  <FlightIcon @name={{@icon}} @color={{@iconColor}} />
   <div>{{@text}}</div>
   {{#if @connection}}
-    <div class="cut-text-with-icon__connection">{{@connection}}</div>
+    <div class='cut-text-with-icon__connection'>{{@connection}}</div>
   {{/if}}
 </div>

--- a/toolkit/src/styles/components/list-item.scss
+++ b/toolkit/src/styles/components/list-item.scss
@@ -73,13 +73,14 @@ button.cut-list-item__content-container {
 .cut-list-item-section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 4px;
 
   &__title-row {
     display: flex;
     flex-direction: row;
     gap: 8px;
     align-items: center;
+    min-height: 24px;
   }
 }
 
@@ -95,7 +96,7 @@ button.cut-list-item__content-container {
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
+  min-height: 24px;
   gap: 8px;
-
   color: var(--token-color-palette-neutral-500);
 }

--- a/toolkit/src/styles/components/text-with-icon.scss
+++ b/toolkit/src/styles/components/text-with-icon.scss
@@ -6,6 +6,11 @@
   display: flex;
   align-items: center;
   gap: 4px;
+
+  > .flight-icon {
+    height: 12px;
+    width: 12px;
+  }
 }
 
 .cut-text-with-icon__connection {


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
A bunch of small styling updates to the list item/list-item-template:
- update cut-text-with-icon to have 12px bounding box (copied how they did this with hds-badge as you can't specify lower than 16px with flight-icon directly)
- Decrease title text size to 14px
- Decrease metadata text size to 13px
- Set rows min height to 24px
- Update health status badges to be medium not small
- Don't show any health badge if the healthchecks are empty
- Add strict mTLS icon with text

### :camera_flash: Screenshots
<img width="1208" alt="Screenshot 2023-09-25 at 9 21 32 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/a7de54fe-2ffd-49bc-b30f-6313752c5bbe">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-6218](https://hashicorp.atlassian.net/browse/CC-6218)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [x] Tests added?
- [x] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-6218]: https://hashicorp.atlassian.net/browse/CC-6218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ