### PR TITLE
Add text property to FilterBar.Sort type

### DIFF
--- a/.changeset/fair-days-impress.md
+++ b/.changeset/fair-days-impress.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Add text property to FilterBar.Sort type definition

--- a/toolkit/src/components/cut/filter-bar/types.ts
+++ b/toolkit/src/components/cut/filter-bar/types.ts
@@ -96,6 +96,7 @@ export interface FilterConfig {
 
 export interface Sort {
   value?: string;
+  text?: string;
 }
 
 export interface Search {


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
There is an invalid/missing property on the FilterBar Sort type. The code expects there to be a `text` property on the sort object so that we know what to display in the toggle button, but the type definition only allows for a `value` string. 

I've also added a ticket for adopting TS in the documentation app so that we can have an easier time catching these issues earlier in development.

### :camera_flash: Screenshots
I brought this build over to cloud-ui in my local branch where I am re-adding sort to the services list ui. [Branch](https://github.com/hashicorp/cloud-ui/compare/CC-6566/services-list-sort)
<img width="1679" alt="Screenshot 2023-09-27 at 10 33 03 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/23bf76f3-9198-493a-a403-0971699cdeb9">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[New issue added for adopting TS usage in the documentation app](https://hashicorp.atlassian.net/browse/CC-6583)
[WIP branch in cloud-ui](https://github.com/hashicorp/cloud-ui/compare/CC-6566/services-list-sort)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
