### PR TITLE
CC-6624: Update FilterBar results text on search

### DIFF
--- a/.changeset/ten-mugs-cheat.md
+++ b/.changeset/ten-mugs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Update FilterBar results text on search to include searched text

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -371,7 +371,7 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
       },
     });
 
-    assert.dom('[data-test-filter-bar-results]').hasText('Searching');
+    assert.dom('[data-test-filter-bar-results]').hasText('Showing results for bloom');
   });
 
   test('shows searching text with the name when there are no filters applied and search is applied no count is passed in and the name is set', async function (assert) {
@@ -384,7 +384,7 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
 
     assert
       .dom('[data-test-filter-bar-results]')
-      .hasText('Searching Service Instances');
+      .hasText('Showing results for bloom');
   });
 
   test('shows a result count with a default text for the name if you pass in a count but no name', async function (assert) {

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -371,7 +371,9 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
       },
     });
 
-    assert.dom('[data-test-filter-bar-results]').hasText('Showing results for bloom');
+    assert
+      .dom('[data-test-filter-bar-results]')
+      .hasText('Showing results for bloom');
   });
 
   test('shows searching text with the name when there are no filters applied and search is applied no count is passed in and the name is set', async function (assert) {

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -83,8 +83,8 @@
         }}
       {{else if this.isFiltering}}
         Filters applied:
-      {{else if this.isSearching}}
-        Searching{{if @name (concat ' ' (pluralize @name))}}
+      {{else if (and this.isSearching this.appliedSearch)}}
+        Showing results for {{this.appliedSearch}}
       {{else}}
         Showing all
         {{if @name (pluralize @name) 'results'}}

--- a/toolkit/src/components/cut/filter-bar/index.ts
+++ b/toolkit/src/components/cut/filter-bar/index.ts
@@ -117,6 +117,10 @@ export default class FilterBarComponent extends Component<FilterBarSignature> {
     return !!this.args.config?.search?.value;
   }
 
+  get appliedSearch(): string {
+    return this.args.config?.search?.value || '';
+  }
+
   isChecked(localConfig: FilterConfig, filter: string, value: unknown) {
     if (Array.isArray(localConfig?.filters?.[filter])) {
       return !!(localConfig?.filters?.[filter] as Filter[]).find(


### PR DESCRIPTION
### :hammer_and_wrench: Description
AC:
- Instead of showing "Searching services" when a user inputs text in the search field update to say "Showing results for 
`<inputed search text>`"
<!-- What code changed, and why? -->

### :camera_flash: Screenshots

https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/36387611-5414-4856-a38e-3f84a18bff40


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
