### PR TITLE
Upgrade @hashicorp/design-system-components to 2.13.0

### DIFF
--- a/.changeset/grumpy-moose-smash.md
+++ b/.changeset/grumpy-moose-smash.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+Upgrade @hashicorp/design-system-components to 2.13.0

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -30,7 +30,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@hashicorp/consul-ui-toolkit": "^2.0.0",
-    "@hashicorp/design-system-components": "^2.12.1",
+    "@hashicorp/design-system-components": "^2.13.0",
     "@hashicorp/ember-flight-icons": "^3.1.2",
     "@types/qunit": "latest",
     "@typescript-eslint/eslint-plugin": "^5.2.0",

--- a/toolkit/package.json
+++ b/toolkit/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-typescript": "^7.22.10",
     "@babel/preset-typescript": "^7.21.0",
     "@embroider/addon-dev": "^3.0.0",
-    "@hashicorp/design-system-components": "^2.12.1",
+    "@hashicorp/design-system-components": "^2.13.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@tsconfig/ember": "^3.0.0",
     "@types/ember": "^4.0.3",

--- a/toolkit/src/styles/components/filter-bar.scss
+++ b/toolkit/src/styles/components/filter-bar.scss
@@ -40,6 +40,7 @@
     row-gap: 12px;
     margin: 12px 0;
     font-size: var(--token-typography-body-200-font-size);
+    line-height: 28px;
 
     p.cut-filter-bar-results-count {
       margin: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,15 +2046,15 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
   integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
-"@hashicorp/design-system-components@^2.12.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-components/-/design-system-components-2.12.1.tgz#6bfd22826da24293d68b4db2d2cb6568f29de750"
-  integrity sha512-tEoakHCzhiCrdjPQN2jwfZwJkKvMS8mp0v4pJpmBFXR83+IoX64dB3gYsYFiSuAOOQOEBBCe1/O1wQFVTXeHdA==
+"@hashicorp/design-system-components@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-components/-/design-system-components-2.13.0.tgz#c47ee3d17da47a6672de47c85e386d7d324037a0"
+  integrity sha512-PgoXbK4LWtj2uh/TIp2JiaEN8Ugc88EvEZSi/CzUC2Vroc9wCrYHHQH2JwNTqLTVeNIvptpRRup25bKV6/059w==
   dependencies:
     "@ember/render-modifiers" "^2.0.5"
     "@ember/test-waiters" "^3.0.2"
-    "@hashicorp/design-system-tokens" "^1.8.0"
-    "@hashicorp/ember-flight-icons" "^3.1.2"
+    "@hashicorp/design-system-tokens" "^1.9.0"
+    "@hashicorp/ember-flight-icons" "^3.1.3"
     dialog-polyfill "^0.5.6"
     ember-a11y-refocus "^3.0.2"
     ember-auto-import "^2.6.3"
@@ -2072,10 +2072,10 @@
     sass "^1.62.1"
     tippy.js "^6.3.7"
 
-"@hashicorp/design-system-tokens@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-tokens/-/design-system-tokens-1.8.0.tgz#8734bc46fbdaf72b694927ba7352694d0da3e8e1"
-  integrity sha512-miRHSodtBJ0mkBkRpppW857U79lk2vIwNTv7bPmIbX1SQJONFsWQaOXJOKGAHEAxxWpGn0M98xnqo3Eol9Y6Eg==
+"@hashicorp/design-system-tokens@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/design-system-tokens/-/design-system-tokens-1.9.0.tgz#1cfd2627d838214c609f25ff6696b3f3d516d9e5"
+  integrity sha512-zmMpnKv4vulhVFVCpqf3oAAR5fQeDDnMxbeJIZllLFCgF2JFoL6C/Irghx4WnBAG8GkLs8CbxjPVtFjSYq+V8w==
 
 "@hashicorp/ember-flight-icons@^3.1.2":
   version "3.1.2"
@@ -2087,10 +2087,25 @@
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.2.0"
 
+"@hashicorp/ember-flight-icons@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-flight-icons/-/ember-flight-icons-3.1.3.tgz#0a28667c1cb5908dd1bb73d30991508bfbf399d3"
+  integrity sha512-Cy/zD6aKqwN1Q+jnF1wJ2QzRx4/6XIVM4x3qO0poi2RHBSzZS/jxwAIqyDXdKiqJha7i/vWP3aGQmDEBqoGKjA==
+  dependencies:
+    "@hashicorp/flight-icons" "^2.20.0"
+    ember-auto-import "^2.6.3"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.2.0"
+
 "@hashicorp/flight-icons@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.19.0.tgz#4088574887232bb50a3c1d6e5044456c90b88e40"
   integrity sha512-FzEHAOLSQMS5yJorF5H3xP4BKfpIUFRnQgkFl6i1RmvwpOJQgeoz9w/QqWvjh+H/DhFomeC6OxHGgD6rZL7phw==
+
+"@hashicorp/flight-icons@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/flight-icons/-/flight-icons-2.20.0.tgz#ef187e9295b2778b24f206ca10ab20f3a627ff76"
+  integrity sha512-CYIY5yAkYzi8Q+w86Mk41IK1/1X+AoQUtxK3Yt48ZHzulsz3Wlvg91YvnOGntxjqcp7AGwpOYnq7xM2W4bummQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Upgrades `@hashicorp/design-system-components` to `2.13.0`. Part of this changes the size of `Hds::Tag` I've updated the filter bar results line height to make it so that it doesn't jump around when you remove all filters due to the change in tag size. There was no token for the corresponding size.

### :camera_flash: Screenshots
![2023-10-10 10-38-32 2023-10-10 10_40_23](https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/dc3d2100-6ef0-425f-93e1-3c3c68bfc85b)


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[HDS Changelog](https://github.com/hashicorp/design-system/blob/main/packages/components/CHANGELOG.md#2130)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
