### PR TITLE
Update search to take width, isInvalid, isLoading

### DIFF
--- a/.changeset/pink-peas-attack.md
+++ b/.changeset/pink-peas-attack.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': minor
+---
+
+Update FilterBar::Search to take width, isInvalid, isLoading

--- a/documentation/app/templates/components/filter-bar.hbs
+++ b/documentation/app/templates/components/filter-bar.hbs
@@ -226,7 +226,7 @@
   as |FB|
 >
   <FB.FilterGroup as |Filters|>
-    <Filters.Search placeholder="Search for services" />
+    <Filters.Search @width="300px" placeholder="Search for services" />
 
     <Filters.Filter
       @name="status"

--- a/toolkit/src/components/cut/filter-bar/search.hbs
+++ b/toolkit/src/components/cut/filter-bar/search.hbs
@@ -7,6 +7,9 @@
     <SG.TextInput
       @type='search'
       @value={{@search}}
+      @width={{@width}}
+      @isInvalid={{@isInvalid}}
+      @isLoading={{@isLoading}}
       placeholder='Search'
       aria-label='Search'
       {{on 'keyup' @onSearchKeyup}}
@@ -18,6 +21,9 @@
   <Hds::Form::TextInput::Base
     @type='search'
     @value={{@search}}
+    @width={{or @width '196px'}}
+    @isInvalid={{@isInvalid}}
+    @isLoading={{@isLoading}}
     placeholder='Search'
     aria-label='Search'
     class='cut-filter-bar-search'

--- a/toolkit/src/styles/components/filter-bar.scss
+++ b/toolkit/src/styles/components/filter-bar.scss
@@ -15,7 +15,6 @@
     justify-content: space-between;
 
     .cut-filter-bar-search {
-      width: 196px;
       height: 36px;
     }
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Allows for setting the `width` and passing `isInvalid`, `isLoading` to the `Cut::FilterBar::Search` component. I figured the other arguments from `Hds::TextInput` should be preset as they are. Still passing splattributes. through

### :camera_flash: Screenshots
<img width="1099" alt="Screenshot 2023-10-10 at 3 27 36 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/afaa4a86-e07d-4f4f-9285-1b8219595024">
<img width="1099" alt="Screenshot 2023-10-10 at 3 27 11 PM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/0ec30576-ae62-4b0d-a712-4988b680cdb2">
<img width="1099" alt="Screenshot 2023-10-10 at 11 14 27 AM" src="https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/9329ff74-80df-4242-99dd-0ac791b9c826">


### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
