### PR TITLE
CC-6659: Auto build toolkit on changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@
 
 ## Running the test application
 
-- Run `yarn prepare` after any changes to the toolkit to build it to be consumed by the documentation app.
-- Run `yarn start:documentation` to start the documentations apps server
+- Run `yarn watch:toolkit` - This will automatically detect changes in the toolkit and build it to be consumed by the documentation app.
+- In a separate terminal, run `yarn start:documentation` to start the documentations apps server
 - Visit the test application at [http://localhost:4200](http://localhost:4200).
 
 ## Adding changelog entries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@
 
 ## Running the test application
 
-- Run `yarn watch:toolkit` - This will automatically detect changes in the toolkit and build it to be consumed by the documentation app.
+- Run `yarn watch:toolkit` - This will automatically re-build the toolkit to be consumed by the documentation app when toolkit file changes are detected via [fb-watchman](https://facebook.github.io/watchman).
 - In a separate terminal, run `yarn start:documentation` to start the documentations apps server
 - Visit the test application at [http://localhost:4200](http://localhost:4200).
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	@yarn prepare 
+	@yarn prepare

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	@yarn prepare 

--- a/documentation/app/templates/components/service-list-item.hbs
+++ b/documentation/app/templates/components/service-list-item.hbs
@@ -368,8 +368,8 @@
           status.</ComponentApi>
 
         <h3 id="options">Options</h3>
-          <ComponentApi @name="hideClusterPath" @type="boolean">
-            Determines whether the cluster ID, partition, and namespace are displayed in the Service List Item. Default value is <CodeInline @code="false" />.
+          <ComponentApi @name="hideClusterPath" @type="boolean" @default="false">
+            Determines whether the cluster ID, partition, and namespace are displayed in the Service List Item.
           </ComponentApi>
 
       </div>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start:addon": "yarn workspace @hashicorp/consul-ui-toolkit run start",
     "start:documentation": "yarn workspace documentation run start",
     "test": "yarn workspaces run test",
-    "watch:toolkit": "watchman-make -p '**/toolkit/src/**' -t build"
+    "watch:toolkit": "watchman watch-del-all && watchman-make -p '**/toolkit/src/**' -t build"
   },
   "devDependencies": {
     "concurrently": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace @hashicorp/consul-ui-toolkit run start",
     "start:documentation": "yarn workspace documentation run start",
-    "test": "yarn workspaces run test"
+    "test": "yarn workspaces run test",
+    "watch:toolkit": "watchman-make -p '**/toolkit/src/**' -t build"
   },
   "devDependencies": {
     "concurrently": "^7.2.1",


### PR DESCRIPTION
### :hammer_and_wrench: Description
Now you can do a `yarn watch:toolkit` which will watch for changes in `toolkit/src` and automatically rebuild so the `documentation` app will have the latest changes.
Before, you had to run `yarn prepare` after each toolkit change.
<!-- What code changed, and why? -->

### :camera_flash: Screenshots

https://github.com/hashicorp/consul-ui-toolkit/assets/23414052/8f64e7d5-e6b6-45f5-845a-e849dc48ab8f


### :link: External Links
[jira](https://hashicorp.atlassian.net/browse/CC-6659)
<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
