### PR TITLE
chore(ember): use unambiguous format when using 3rd party helpers

### DIFF
--- a/toolkit/src/components/cut/copy-block/index.hbs
+++ b/toolkit/src/components/cut/copy-block/index.hbs
@@ -7,7 +7,7 @@
   <div class='cut-copy-block__copy-button'>
     <CopyButton
       @text={{@clipboardText}}
-      @onSuccess={{perform this.copied}}
+      @onSuccess={{ (perform this.copied) }}
       class={{if
         this.isSuccessfullyCopied
         'cut-copy-block__copy-button--checked'

--- a/toolkit/src/components/cut/filter-bar/filter/filter-input.hbs
+++ b/toolkit/src/components/cut/filter-bar/filter/filter-input.hbs
@@ -5,11 +5,11 @@
 {{#let @components as |Components|}}
   <Components.Header @hasDivider={{true}}>
     <Hds::Form::TextInput::Base
-      @type={{or @type 'search'}}
+      @type={{ (or @type 'search') }}
       @value={{@value}}
       style='margin: 8px 0;'
-      placeholder={{or @placeholder 'Search'}}
-      aria-label={{or @placeholder 'Search'}}
+      placeholder={{ (or @placeholder 'Search') }}
+      aria-label={{ (or @placeholder 'Search') }}
       {{on 'input' @onInput}}
     />
   </Components.Header>
@@ -21,7 +21,7 @@
       >
         <span>{{@label}}</span>
         {{#if @count}}
-          <span>{{or @count 0}}</span>
+          <span>{{ (or @count 0) }}</span>
         {{/if}}
       </span>
     </Components.Generic>

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -77,7 +77,7 @@
     <p class='cut-filter-bar-results-count' data-test-filter-bar-results>
       {{#if this.hasCount}}
         Showing
-        {{pluralize @count (if @name @name 'result')}}{{if
+        {{ (pluralize @count (if @name @name 'result')) }}{{if
           @totalCount
           (concat ' of ' @totalCount)
         }}
@@ -92,16 +92,16 @@
     </p>
 
     {{#each this.appliedFilters as |filter|}}
-      <p class='cut-filter-bar-applied-filter-label'>{{titlecase
+      <p class='cut-filter-bar-applied-filter-label'>{{ (titlecase
           filter.name
-        }}:</p>
+        ) }}:</p>
 
       {{#each filter.value as |filterValue|}}
         {{#if filter.isRequired}}
-          <Hds::Tag @text={{titlecase filterValue.text}} />
+          <Hds::Tag @text={{ (titlecase filterValue.text) }} />
         {{else}}
           <Hds::Tag
-            @text={{titlecase filterValue.text}}
+            @text={{ (titlecase filterValue.text) }}
             @onDismiss={{fn
               this.toggleFilterValue
               (hash

--- a/toolkit/src/components/cut/list/pagination.hbs
+++ b/toolkit/src/components/cut/list/pagination.hbs
@@ -7,8 +7,8 @@
     <Hds::Pagination::Compact
       class='cut-list-pagination_page-selector'
       @showLabels={{true}}
-      @isDisabledPrev={{not @prevCursor}}
-      @isDisabledNext={{not @nextCursor}}
+      @isDisabledPrev={{ (not @prevCursor) }}
+      @isDisabledNext={{ (not @nextCursor) }}
       @onPageChange={{@onPageChange}}
     />
   {{else}}
@@ -16,12 +16,12 @@
       class='cut-list-pagination_page-selector'
       @showLabels={{true}}
       @queryFunction={{this.queryFunction}}
-      @route={{or @route this.router.currentRouteName}}
+      @route={{ (or @route this.router.currentRouteName) }}
       @model={{@model}}
       @models={{@models}}
       @replace={{@replace}}
-      @isDisabledPrev={{not @prevCursor}}
-      @isDisabledNext={{not @nextCursor}}
+      @isDisabledPrev={{ (not @prevCursor) }}
+      @isDisabledNext={{ (not @nextCursor) }}
     />
   {{/if}}
 

--- a/toolkit/src/components/cut/metadata/tags/index.hbs
+++ b/toolkit/src/components/cut/metadata/tags/index.hbs
@@ -3,5 +3,5 @@
 }}
 
 {{#if @tags}}
-  <Cut::TextWithIcon @icon="tag" @text={{join ', ' (union (or @tags (array)))}} data-test-tags/>
+  <Cut::TextWithIcon @icon="tag" @text={{ (join ', ' (union (or @tags (array)))) }} data-test-tags/>
 {{/if}}


### PR DESCRIPTION


### :hammer_and_wrench: Description

OK, we were working on enabling the strictest embroider settings in HCP, and some CUT components came up in the context of using unambiguous helper syntax. To read more about what this is and what embroider is doing, check out the comment in embroider: 
https://github.com/embroider-build/embroider/blob/main/packages/compat/src/resolver-transform.ts#L458-L504

So! This PR updates bare helper usage to alway use the unambiguous format. Did I get all of them? I don't know, but I tried.
<!-- What code changed, and why? -->



