### PR TITLE
CC-6658: Update changeset config release as public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["documentation"]
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? -->
Sometimes you just need to read the docs, amirite. Updates the changeset config so that releases are published as `public`. Prior to this I would have to toggle them back to public after releasing. 

Also updates the `documentation` app to be ignored so if you run `yarn changeset` you don't have to manually select the toolkit. 

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
[CC-6658](https://hashicorp.atlassian.net/browse/CC-6658)
[Docs](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#access-restricted--public)

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"


[CC-6658]: https://hashicorp.atlassian.net/browse/CC-6658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ