### PR TITLE
chore: run ember-angle-bracket codemod to convert unambiguous helper usage

### DIFF
--- a/toolkit/src/components/cut/filter-bar/filter/filter-input.hbs
+++ b/toolkit/src/components/cut/filter-bar/filter/filter-input.hbs
@@ -21,7 +21,7 @@
       >
         <span>{{@label}}</span>
         {{#if @count}}
-          <span>{{or @count 0}}</span>
+          <span>{{(or @count 0)}}</span>
         {{/if}}
       </span>
     </Components.Generic>

--- a/toolkit/src/components/cut/filter-bar/filter/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/filter/index.hbs
@@ -6,7 +6,7 @@
   {{#let @dropdown this.filterCount as |Dropdown filterCount|}}
     <Dropdown
       @listPosition={{if @listPosition @listPosition 'bottom-right'}}
-      @onClose={{fn @clearPendingFilter @name}}
+      @onClose={{(fn @clearPendingFilter @name)}}
       ...attributes
       as |DD|
     >
@@ -85,7 +85,7 @@
 {{else}}
   <Hds::Dropdown
     @listPosition={{if @listPosition @listPosition 'bottom-right'}}
-    @onClose={{fn @clearPendingFilter @name}}
+    @onClose={{(fn @clearPendingFilter @name)}}
     ...attributes
     as |DD|
   >

--- a/toolkit/src/components/cut/filter-bar/index.hbs
+++ b/toolkit/src/components/cut/filter-bar/index.hbs
@@ -77,24 +77,19 @@
     <p class='cut-filter-bar-results-count' data-test-filter-bar-results>
       {{#if this.hasCount}}
         Showing
-        {{pluralize @count (if @name @name 'result')}}{{if
-          @totalCount
-          (concat ' of ' @totalCount)
-        }}
+        {{(pluralize @count (if @name @name 'result'))}}{{(if @totalCount (concat ' of ' @totalCount))}}
       {{else if this.isFiltering}}
         Filters applied:
       {{else if (and this.isSearching this.appliedSearch)}}
         Showing results for {{this.appliedSearch}}
       {{else}}
         Showing all
-        {{if @name (pluralize @name) 'results'}}
+        {{(if @name (pluralize @name) 'results')}}
       {{/if}}
     </p>
 
     {{#each this.appliedFilters as |filter|}}
-      <p class='cut-filter-bar-applied-filter-label'>{{titlecase
-          filter.name
-        }}:</p>
+      <p class='cut-filter-bar-applied-filter-label'>{{(titlecase filter.name)}}:</p>
 
       {{#each filter.value as |filterValue|}}
         {{#if filter.isRequired}}


### PR DESCRIPTION
This is a retry of #85, but done with the angle-bracket codemod which now will do the conversion for you. There were a lot of errors about `yield` usage, but I will leave those for now - I'd be surprised if that's not on the included helper list.

As noted[ in the docs](https://github.com/ember-codemods/ember-angle-brackets-codemod?tab=readme-ov-file#usage), I started the dev server and then ran: 
```npx ember-angle-brackets-codemod --telemetry=http://localhost:4200 ./toolkit/src/components/cut/```

I then manually fixed the `fn` usage as there were errors in the codemod log around it.


### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
