### PR TITLE
feature(filter-bar): don't render active filter count unless isMultiS…

### DIFF
--- a/.changeset/gold-zoos-sin.md
+++ b/.changeset/gold-zoos-sin.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/consul-ui-toolkit': patch
+---
+
+FilterBar::Filter - only render active filter count if isMultiSelect is true

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -15,7 +15,13 @@ import {
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-async function setupTest({ config, name, count, totalCount, isMultiSelect } = {}) {
+async function setupTest({
+  config,
+  name,
+  count,
+  totalCount,
+  isMultiSelect,
+} = {}) {
   this.set('name', name);
 
   this.set('count', count);

--- a/documentation/tests/integration/components/filter-bar-test.js
+++ b/documentation/tests/integration/components/filter-bar-test.js
@@ -15,12 +15,14 @@ import {
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-async function setupTest({ config, name, count, totalCount } = {}) {
+async function setupTest({ config, name, count, totalCount, isMultiSelect } = {}) {
   this.set('name', name);
 
   this.set('count', count);
 
   this.set('totalCount', totalCount);
+
+  this.set('isMultiSelect', isMultiSelect ?? true);
 
   this.set(
     'config',
@@ -56,7 +58,7 @@ async function setupTest({ config, name, count, totalCount } = {}) {
         <Filters.Filter
           @name="status"
           @batch={{true}}
-          @isMultiSelect={{true}}
+          @isMultiSelect={{this.isMultiSelect}}
           as |F|
         >
           <F.ToggleButton @text="Status" data-test-status-filter />
@@ -469,5 +471,45 @@ module('Integration | Component | cut/filter-bar', function (hooks) {
     await setupTest.call(this);
 
     assert.dom('[data-test-search]').hasNoValue();
+  });
+
+  test('it renders the number of active filters in the dropdown toggle when isMultiSelect is true', async function (assert) {
+    await setupTest.call(this);
+
+    assert
+      .dom('[data-test-status-filter] .hds-badge-count')
+      .hasText('2', 'There are two active filters');
+  });
+
+  test('it does not render the number of active filters in the dropdown toggle when isMultiSelect is false', async function (assert) {
+    await setupTest.call(this, {
+      isMultiSelect: false,
+      config: {
+        search: {
+          value: '',
+        },
+        filters: {
+          status: [
+            {
+              text: 'Warning',
+              value: 'warning',
+            },
+          ],
+          juice: {
+            text: 'Orange',
+            value: 'oj',
+            isRequired: true,
+          },
+        },
+        sort: {
+          text: 'critical to healthy',
+          value: 'health',
+        },
+      },
+    });
+
+    assert
+      .dom('[data-test-status-filter] .hds-badge-count')
+      .doesNotExist('It does not render the badge count');
   });
 });

--- a/toolkit/src/components/cut/filter-bar/filter/index.ts
+++ b/toolkit/src/components/cut/filter-bar/filter/index.ts
@@ -28,7 +28,7 @@ export default class FilterComponent extends Component<FilterSignature> {
   }
 
   get filterCount(): string | undefined {
-    if (!this.args.config?.filters) {
+    if (!this.args.config?.filters || !this.args.isMultiSelect) {
       return undefined;
     }
 


### PR DESCRIPTION
…elect is true

Previously, the Filter component under FilterBar would always render a count badge for active filters. This PR changes it so that count only gets rendered if `isMultiSelect` is `true`.

### :hammer_and_wrench: Description

<!-- What code changed, and why? -->

### :camera_flash: Screenshots

### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [ ] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
