### PR TITLE
Disable a11y refocus on sidenav

### DIFF
--- a/documentation/app/templates/application.hbs
+++ b/documentation/app/templates/application.hbs
@@ -5,7 +5,7 @@
 {{page-title "Consul UI Toolkit"}}
 
 <div class="application">
-  <Hds::SideNav>
+  <Hds::SideNav @hasA11yRefocus={{false}}>
     <:header>
       <Hds::SideNav::Header>
         <:logo>


### PR DESCRIPTION
### :hammer_and_wrench: Description
I was looking through the toolkit documentation and I noticed it was having the same sidenav refocus issue that was fixed in consul ui. I went ahead and disabled that on `HDS::SideNav`.


<!-- What code changed, and why? -->

### :camera_flash: Screenshots
Here's a video demonstrating before and after. Apologies there is no audio at this time.



[video](https://github.com/hashicorp/consul-ui-toolkit/assets/5448834/841c345d-ebc4-4d81-b3f4-ce1e5b6328ed)



### :link: External Links

<!-- Issues, RFC, etc. Use the JIRA issue name (HCPE-123, HCP-123) to auto-link the PR to JIRA. -->
https://github.com/hashicorp/consul/pull/20111

### :building_construction: How to Build and Test the Change

<!-- List steps to test your change on a local environment. -->

### :+1: Definition of Done

- [x] New functionality works?
- [ ] Tests added?
- [ ] Docs updated?

### :speech_balloon: Using the [Netlify feedback ladder](https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/)

- :mount_fuji: **[mountain]**: Blocking and requires immediate action.
- :moyai: **[boulder]**: Blocking.
- :white_circle: **[pebble]**: Non-blocking, but requires future action.
- :hourglass_flowing_sand: **[sand]**: Non-blocking, but requires future consideration.
- :sparkles: **[dust]**: Non-blocking. "Take it or leave it"
